### PR TITLE
Feature: Allow too many args

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -225,7 +225,7 @@ impl FromIterator<String> for ArgsAction {
                 // NOTE: 'version' is already handled by fend itself
                 (Repl | Eval(_), "--version" | "-v" | "-V") | (Version, _) => Version,
                 // If neither help nor version is requested, evaluate the arguments
-                // Ignore
+                // Ignore empty arguments, so that `$ fend "" ""` will enter the repl.
                 (Repl, arg) if !arg.trim().is_empty() => Eval(String::from(arg)),
                 (Repl, _) => Repl,
                 (Eval(eval), arg) => Eval(eval + " " + arg),


### PR DESCRIPTION
Fixes #118.

I've added some tests and tried some things by hand. It seems to be working as expected.
I also took the liberty to extract the content into a `real_main` function, as mentioned [here](https://doc.rust-lang.org/std/process/fn.exit.html). If you would rather stick to the previous version, just let me know and I'll revert.

# Corner cases
- `$ fend "" ""` will start the repl. I don't know why you would enter something like this.. We could alternatively evaluate `""`
- `$ fend -v -h` will print the help which contains the version.