### PR TITLE
[WIP] Remove rustyline dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,16 +35,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
-name = "buf_redux"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b953a6887648bb07a535631f2bc00fbdb2a2216f135552cb3f534ed136b9c07f"
-dependencies = [
- "memchr",
- "safemem",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -63,17 +53,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "clipboard-win"
-version = "4.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f3e1238132dc01f081e1cbb9dace14e5ef4c3a51ee244bd982275fb514605db"
-dependencies = [
- "error-code",
- "str-buf",
- "winapi",
-]
-
-[[package]]
 name = "ctrlc"
 version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -81,54 +60,6 @@ checksum = "a19c6cedffdc8c03a3346d723eb20bd85a13362bb96dc2ac000842c6381ec7bf"
 dependencies = [
  "nix",
  "winapi",
-]
-
-[[package]]
-name = "endian-type"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
-
-[[package]]
-name = "errno"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
-dependencies = [
- "errno-dragonfly",
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "errno-dragonfly"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
-name = "error-code"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64f18991e7bf11e7ffee451b5318b5c1a73c52d0d0ada6e5a3017c8c1ced6a21"
-dependencies = [
- "libc",
- "str-buf",
-]
-
-[[package]]
-name = "fd-lock"
-version = "3.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02ecad9808e0596f8956d14f7fa868f996290bd01c8d7329d6e5bc2bb76adf8f"
-dependencies = [
- "cfg-if",
- "rustix",
- "windows-sys",
 ]
 
 [[package]]
@@ -141,7 +72,6 @@ dependencies = [
  "fend-core",
  "home",
  "nanorand",
- "rustyline-with-hint-fix",
  "serde",
  "toml",
 ]
@@ -191,12 +121,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "io-lifetimes"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec58677acfea8a15352d42fc87d11d63596ade9239e0a7c9352914417515dbe6"
-
-[[package]]
 name = "js-sys"
 version = "0.3.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -218,12 +142,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bf2e165bb3457c8e098ea76f3e3bc9db55f87aa90d52d0e6be741470916aaa4"
 
 [[package]]
-name = "linux-raw-sys"
-version = "0.0.42"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5284f00d480e1c39af34e72f8ad60b94f47007e3481cd3b731c1d67190ddc7b7"
-
-[[package]]
 name = "log"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -231,12 +149,6 @@ checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
  "cfg-if",
 ]
-
-[[package]]
-name = "memchr"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
 name = "memoffset"
@@ -252,15 +164,6 @@ name = "nanorand"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "729eb334247daa1803e0a094d0a5c55711b85571179f5ec6e53eccfdf7008958"
-
-[[package]]
-name = "nibble_vec"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
-dependencies = [
- "smallvec",
-]
 
 [[package]]
 name = "nix"
@@ -294,82 +197,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "radix_trie"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
-dependencies = [
- "endian-type",
- "nibble_vec",
-]
-
-[[package]]
-name = "rustix"
-version = "0.33.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef7ec6a44fba95d21fa522760c03c16ca5ee95cebb6e4ef579cab3e6d7ba6c06"
-dependencies = [
- "bitflags",
- "errno",
- "io-lifetimes",
- "libc",
- "linux-raw-sys",
- "winapi",
-]
-
-[[package]]
-name = "rustyline-with-hint-fix"
-version = "9.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23589823b9d113abba3c51a378cfdc469249a96a5fbd789ca43f307286f9053d"
-dependencies = [
- "bitflags",
- "buf_redux",
- "cfg-if",
- "clipboard-win",
- "fd-lock",
- "libc",
- "log",
- "memchr",
- "nix",
- "radix_trie",
- "scopeguard",
- "smallvec",
- "unicode-segmentation",
- "unicode-width",
- "utf8parse",
- "winapi",
-]
-
-[[package]]
-name = "safemem"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
-
-[[package]]
-name = "scopeguard"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
-
-[[package]]
 name = "serde"
 version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
-
-[[package]]
-name = "smallvec"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
-
-[[package]]
-name = "str-buf"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d44a3643b4ff9caf57abcee9c2c621d6c03d9135e0d8b589bd9afb5992cb176a"
 
 [[package]]
 name = "syn"
@@ -392,28 +223,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
-
-[[package]]
-name = "unicode-width"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
-
-[[package]]
 name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
-
-[[package]]
-name = "utf8parse"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "936e4b492acfd135421d8dca4b1aa80a7bfc26e702ef3af710e0752684df5372"
 
 [[package]]
 name = "wasm-bindgen"
@@ -500,46 +313,3 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows-sys"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "030b7ff91626e57a05ca64a07c481973cbb2db774e4852c9c7ca342408c6a99a"
-dependencies = [
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29277a4435d642f775f63c7d1faeb927adba532886ce0287bd985bffb16b6bca"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1145e1989da93956c68d1864f32fb97c8f561a8f89a5125f6a2b7ea75524e4b8"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4a09e3a0d4753b73019db171c1339cd4362c8c44baf1bcea336235e955954a6"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ca64fcb0220d58db4c119e050e7af03c69e6f4f415ef69ec1773d9aab422d5a"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08cabc9f0066848fef4bc6a1c1668e6efce38b661d2aeec75d18d8617eebb5f1"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,6 +71,7 @@ dependencies = [
  "ctrlc",
  "fend-core",
  "home",
+ "libc",
  "nanorand",
  "serde",
  "toml",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -13,7 +13,6 @@ edition = "2021"
 categories = ["command-line-utilities", "mathematics", "science"]
 
 [dependencies]
-rustyline = { version =  "9.1.4", default-features = false, package = "rustyline-with-hint-fix" }
 home = "0.5.3"
 ctrlc = "3.2.1"
 ansi_term = "0.12.1"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -21,6 +21,7 @@ serde = { version = "1.0.136", default-features = false }
 nanorand = { version = "0.6.1", default-features = false, features = ["std", "wyrand"] }
 #console = { version = "0.15.0", default-features = false }
 atty = "0.2.14"
+libc = "0.2.119"
 
 [dependencies.fend-core]
 version = "1.0.0"

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -140,8 +140,8 @@ pub static DEFAULT_CONFIG_FILE: &str = include_str!("default_config.toml");
 
 fn read_config_file() -> Config {
     let path = match crate::file_paths::get_config_file_location() {
-        Some(path) => path,
-        None => return Config::default(),
+        Ok(path) => path,
+        Err(_) => return Config::default(),
     };
     let mut file = match fs::File::open(&path) {
         Ok(file) => file,

--- a/cli/src/file_paths.rs
+++ b/cli/src/file_paths.rs
@@ -1,47 +1,61 @@
-use std::{env, fs, path};
+use std::{env, error, fmt, path};
 
-fn get_home_dir() -> Option<path::PathBuf> {
-    let home_dir = home::home_dir()?;
-    Some(home_dir)
+#[derive(Debug)]
+pub struct HomeDirError;
+
+impl fmt::Display for HomeDirError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "unable to find home directory")
+    }
 }
 
-fn get_config_dir() -> Option<path::PathBuf> {
+impl error::Error for HomeDirError {}
+
+fn get_home_dir() -> Result<path::PathBuf, HomeDirError> {
+    let home_dir = match home::home_dir() {
+        Some(home_dir) => home_dir,
+        None => return Err(HomeDirError),
+    };
+    Ok(home_dir)
+}
+
+fn get_config_dir() -> Result<path::PathBuf, HomeDirError> {
     // first try $FEND_CONFIG_DIR
     if let Some(env_var_config_dir) = env::var_os("FEND_CONFIG_DIR") {
-        return Some(path::PathBuf::from(env_var_config_dir));
+        return Ok(path::PathBuf::from(env_var_config_dir));
     }
 
     // otherwise try $XDG_CONFIG_HOME/fend/
     if let Some(env_var_xdg_config_dir) = env::var_os("XDG_CONFIG_HOME") {
         let mut res = path::PathBuf::from(env_var_xdg_config_dir);
         res.push("fend");
-        return Some(res);
+        return Ok(res);
     }
 
     // otherwise use $HOME/.config/fend/
     let mut res = get_home_dir()?;
     res.push(".config");
     res.push("fend");
-    Some(res)
+    Ok(res)
 }
 
-pub fn get_config_file_location() -> Option<path::PathBuf> {
+pub fn get_config_file_location() -> Result<path::PathBuf, HomeDirError> {
     let mut config_path = get_config_dir()?;
     config_path.push("config.toml");
-    Some(config_path)
+    Ok(config_path)
 }
 
-fn get_history_dir() -> Option<path::PathBuf> {
+pub fn get_state_dir() -> Result<path::PathBuf, HomeDirError> {
     // first try $FEND_STATE_DIR
     if let Some(env_var_history_dir) = env::var_os("FEND_STATE_DIR") {
-        return Some(path::PathBuf::from(env_var_history_dir));
+        return Ok(path::PathBuf::from(env_var_history_dir));
     }
 
     // otherwise try $XDG_STATE_HOME/fend/
     if let Some(env_var_xdg_state_dir) = env::var_os("XDG_STATE_HOME") {
         let mut res = path::PathBuf::from(env_var_xdg_state_dir);
         res.push("fend");
-        return Some(res);
+        return Ok(res);
     }
 
     // otherwise use $HOME/.local/state/fend/
@@ -49,15 +63,5 @@ fn get_history_dir() -> Option<path::PathBuf> {
     res.push(".local");
     res.push("state");
     res.push("fend");
-    Some(res)
-}
-
-pub fn get_history_file_location() -> Option<path::PathBuf> {
-    let mut history_path = get_history_dir()?;
-    match fs::create_dir_all(history_path.as_path()) {
-        Ok(_) => (),
-        Err(_) => return None,
-    }
-    history_path.push("history");
-    Some(history_path)
+    Ok(res)
 }

--- a/cli/src/helper.rs
+++ b/cli/src/helper.rs
@@ -1,4 +1,4 @@
-use crate::{config, context::Context};
+/*use crate::{config, context::Context};
 use std::time;
 
 pub struct HintInterrupt {
@@ -109,4 +109,4 @@ impl rustyline::completion::Completer for Helper<'_> {
     }
 }
 
-impl rustyline::Helper for Helper<'_> {}
+impl rustyline::Helper for Helper<'_> {}*/

--- a/cli/src/history.rs
+++ b/cli/src/history.rs
@@ -1,0 +1,68 @@
+use crate::file_paths;
+use std::{cmp, error, fs, io, path};
+
+pub struct History {
+    entries: Vec<String>,
+    hist_file_length: usize,
+}
+
+impl History {
+    pub fn load(hist_file_length: usize) -> Result<Self, Box<dyn error::Error>> {
+        let location = Self::location()?;
+        if !location.is_file() {
+            return Ok(Self {
+                entries: vec![],
+                hist_file_length,
+            });
+        }
+        let file = fs::read_to_string(location)?;
+        let mut entries = vec![];
+        for line in file.lines() {
+            entries.push(line.replace("\\n", "\n").replace("\\\\", "\\"));
+        }
+        Ok(Self {
+            entries,
+            hist_file_length,
+        })
+    }
+
+    pub fn add_entry(&mut self, entry: &str) {
+        if entry.starts_with(' ') {
+            return;
+        }
+        self.entries.push(entry.to_string());
+    }
+
+    pub fn _get(&self, idx: usize) -> &str {
+        &self.entries[idx]
+    }
+
+    pub fn _len(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub fn location() -> Result<path::PathBuf, file_paths::HomeDirError> {
+        let mut history_path = file_paths::get_state_dir()?;
+        history_path.push("history");
+        Ok(history_path)
+    }
+
+    pub fn write(&self) -> Result<(), Box<dyn error::Error>> {
+        let mut history_path = file_paths::get_state_dir()?;
+        if !history_path.exists() {
+            fs::create_dir_all(&history_path)?;
+        }
+        history_path.push("history");
+        let mut f = fs::OpenOptions::new()
+            .write(true)
+            .truncate(true)
+            .open(&history_path)?;
+        let start_idx = cmp::max(self.entries.len(), self.hist_file_length) - self.hist_file_length;
+        for line in &self.entries[start_idx..] {
+            let mut line = line.replace("\\", "\\\\").replace("\n", "\\n");
+            line.push('\n');
+            io::Write::write(&mut f, line.as_bytes())?;
+        }
+        Ok(())
+    }
+}

--- a/cli/src/interrupt.rs
+++ b/cli/src/interrupt.rs
@@ -6,12 +6,16 @@ pub struct CtrlC {
 
 impl fend_core::Interrupt for CtrlC {
     fn should_interrupt(&self) -> bool {
-        let running = self.running.load(sync::atomic::Ordering::Relaxed);
-        !running
+        self.interrupted()
     }
 }
 
 impl CtrlC {
+    pub fn interrupted(&self) -> bool {
+        let running = self.running.load(sync::atomic::Ordering::Relaxed);
+        !running
+    }
+
     pub fn reset(&self) {
         self.running.store(true, sync::atomic::Ordering::SeqCst);
     }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,4 +1,3 @@
-#![forbid(unsafe_code)]
 #![deny(clippy::all)]
 #![deny(clippy::pedantic)]
 #![deny(elided_lifetimes_in_paths)]
@@ -172,6 +171,7 @@ fn repl_loop(config: &config::Config) -> Result<i32, Box<dyn error::Error>> {
     let mut initial_run = true; // set to false after first successful command
     let mut last_command_success = true;
     let interrupt = interrupt::register_handler();
+    //let _exit_raw_mode = terminal::enable_raw_mode()?;
     loop {
         let line = match read_line(config, &interrupt) {
             Ok(ReadLineResult::Line(line)) => line,

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -112,10 +112,12 @@ fn read_line(
     config: &config::Config,
     interrupt: &interrupt::CtrlC,
 ) -> Result<ReadLineResult, io::Error> {
-    let mut line = String::new();
-    print!("{}", config.prompt.as_str());
+
+    let mut stdout = io::stdout();
+    io::Write::write(&mut stdout, config.prompt.as_bytes())?;
     io::Write::flush(&mut io::stdout())?;
-    line.clear();
+
+    let mut line = String::new();
     io::BufRead::read_line(&mut io::stdin().lock(), &mut line)?;
     if line.ends_with('\n') {
         line.pop();

--- a/cli/src/terminal.rs
+++ b/cli/src/terminal.rs
@@ -1,4 +1,5 @@
 // contains a wrapper around terminal handling
+//use std::{io, mem};
 
 pub fn atty_stdout() -> bool {
     // check if stdout is a tty (which affects whether to show colors)
@@ -10,3 +11,52 @@ pub fn atty_stdin() -> bool {
     // interactive prompt)
     atty::is(atty::Stream::Stdin)
 }
+
+/*#[cfg(unix)]
+pub struct ExitRawMode {
+    fd: libc::c_int,
+    close_fd: bool,
+    termios: libc::termios
+}
+
+impl Drop for ExitRawMode {
+    fn drop(&mut self) {
+        match wrap_result(unsafe { libc::tcsetattr(self.fd, libc::TCSANOW, &self.termios) }) {
+            Ok(()) => (),
+            Err(e) => {
+                eprintln!("Error: {e}");
+            }
+        }
+        if self.close_fd {
+            let _ = unsafe { libc::close(self.fd) };
+        }
+    }
+}
+
+#[cfg(unix)]
+pub fn enable_raw_mode() -> io::Result<ExitRawMode> {
+    let (fd, close_fd) = (libc::STDIN_FILENO, false);
+    let mut termios = unsafe {
+        let mut termios = mem::zeroed();
+        wrap_result(libc::tcgetattr(fd, &mut termios))?;
+        termios
+    };
+    let original_mode_ios = termios;
+
+    unsafe {
+        libc::cfmakeraw(&mut termios)
+    }
+    unsafe {
+        wrap_result(libc::tcsetattr(fd, libc::TCSANOW, &termios))?;
+    }
+
+    Ok(ExitRawMode { fd, close_fd, termios: original_mode_ios })
+}
+
+fn wrap_result(result: i32) -> io::Result<()> {
+    if result == -1 {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
+}*/


### PR DESCRIPTION
Remaining issues:
- [ ] Inconsistent Ctrl-D behaviour after input was typed
- [ ] History support
    - [x] Read and write history file
    - [x] Use history length from config
    - [ ] Append without rewriting
    - [ ] Line length limit
    - [ ] Multiple fend processes without interference
    - [ ] Arrow key navigation
- [ ] Ctrl-C (on the prompt)
- [ ] Live preview
- [ ] Tab completion