### PR TITLE
Re-enable cargo strip support (requires Rust 1.59)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -70,11 +70,6 @@ jobs:
         if: ${{ matrix.platform == 'ubuntu-latest' }}
         uses: codecov/codecov-action@v2.1.0
 
-      - name: Strip binary
-        if: ${{ matrix.platform == 'ubuntu-latest' || matrix.platform == 'macos-latest' }}
-        run: |
-          strip ${{ matrix.artifact-path }}
-
       - name: Upload artifacts
         uses: actions/upload-artifact@v2.3.1
         with:
@@ -87,7 +82,6 @@ jobs:
         run: |
           rustup target add aarch64-apple-darwin
           cargo build --release --package fend --target aarch64-apple-darwin
-          strip target/aarch64-apple-darwin/release/fend
 
       - name: Upload artifacts (Apple Silicon)
         uses: actions/upload-artifact@v2.3.1
@@ -105,7 +99,6 @@ jobs:
           sudo apt-get install -yq gcc-arm-linux-gnueabihf
           export CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER=/usr/bin/arm-linux-gnueabihf-gcc
           cargo build --release --package fend --target armv7-unknown-linux-gnueabihf
-          arm-linux-gnueabihf-strip target/armv7-unknown-linux-gnueabihf/release/fend
 
       - name: Upload artifacts (linux-armv7-gnueabihf)
         uses: actions/upload-artifact@v2.3.1
@@ -123,7 +116,6 @@ jobs:
           sudo apt-get install -yq gcc-aarch64-linux-gnu
           export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=/usr/bin/aarch64-linux-gnu-gcc
           cargo build --release --package fend --target aarch64-unknown-linux-gnu
-          aarch64-linux-gnu-strip target/aarch64-unknown-linux-gnu/release/fend
 
       - name: Upload artifacts (linux-aarch64-gnu)
         uses: actions/upload-artifact@v2.3.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,4 @@ members = ["cli", "core", "wasm"]
 [profile.release]
 lto = true
 opt-level = "z" # small code size
+strip = "symbols"


### PR DESCRIPTION
Reverts 5b91ee0a2afce59d6370114fee4767937ccd8a84, i.e. re-enables 39cdf3809df93b417790e274260f27cf75a2486b.

Merge this when Rust 1.59 has been out for a while longer.