### PR TITLE
Implicitly convert percentages better

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -142,7 +142,7 @@ jobs:
 
       - name: Upload artifacts (MSIX)
         uses: actions/upload-artifact@v2.3.1
-        if: ${{ matrix.platform == 'windows-latest' }}
+        if: ${{ github.ref == 'refs/heads/main' && matrix.platform == 'windows-latest' }}
         with:
           name: fend-${{ env.FEND_VERSION }}-windows-x64-msix
           path: windows-msix/fend.msix

--- a/core/src/num/unit/unit_exponent.rs
+++ b/core/src/num/unit/unit_exponent.rs
@@ -39,6 +39,11 @@ impl UnitExponent {
         })
     }
 
+    pub(crate) fn is_percentage_unit(&self) -> bool {
+        let (prefix, name) = self.unit.prefix_and_name(false);
+        prefix.is_empty() && ["%", "percent"].contains(&name)
+    }
+
     pub(crate) fn add_to_hashmap<I: Interrupt>(
         &self,
         hashmap: &mut HashMap<BaseUnit, Complex>,

--- a/core/tests/integration_tests.rs
+++ b/core/tests/integration_tests.rs
@@ -2114,9 +2114,13 @@ fn one_plus_five_percent() {
 }
 
 #[test]
-#[ignore]
 fn five_percent_times_five_percent() {
     test_eval("5% * 5%", "0.25%");
+}
+
+#[test]
+fn five_percent_times_kg() {
+    test_eval("5% * 8 kg", "0.4 kg");
 }
 
 #[test]

--- a/core/tests/integration_tests.rs
+++ b/core/tests/integration_tests.rs
@@ -2124,6 +2124,27 @@ fn five_percent_times_kg() {
 }
 
 #[test]
+fn five_percent_times_100() {
+    /*
+     * as discussed in the "simplify" function,
+     * there are two ways to view this:
+     *
+     * 1. 5% of 100 (giving 5)
+     * 2. 100x 5% (giving 500%)
+     *
+     * Mathematically they are equivalent values.
+     * However, from a UI perspective they are not.
+     *
+     * I (Techcable) suggest overloading the "of" operator for that purpose.
+     * For example "5% of 100 => 5".
+     *
+     * This would work for all values, and would specifically require that the
+     * left side is formatted as a percentage.
+     */
+    test_eval("5% * 100", "500%");
+}
+
+#[test]
 fn units_1() {
     test_eval("0m + 1kph * 1 hr", "1000 m");
 }


### PR DESCRIPTION
Currently the behavior is not what you would expect (See #164).

In practice, percentages are usually used as scalar multipliers,
not as "units" in the traditional sense.

~~## Propsed Change to Multiplication~~
<details>
   <summary>This was a failure, it broke too many internals</summary>
I propose changing the rules of multiplication to treat percentages as unit-less scalars in some situations.

This means 80 kg * 5% will now return 4 kg, instead of "400 kg %".

There is one case when the percentage is not converted into a scalar:
If it is on the left hand side, and no other units are involved.

In this case, the user most likely intended the query to be about the percentage itself.

This means "5% * 5% = .25%" and "5% * 5 = 25"

If the percentage is on the right hand side, then it is unconditionally converted,
regardless of whether other units are involved.

This means "100 * 5% = 5", despite the fact that "5% * 100 = 500%"

Although in a sense this makes the operation non-commutative,
this is really just a UI thing (the underlying value is the same).
</details>

## New rules to simplify percentages
 Here are the new rules added to the `simplify` function specifically for percentages.

1. If there are any other units (kg, lbs, etc..) then all of the percentages are removed (fixing first problem)
2. No more than one "percentage unit" is permitted.

Rule one fixes cases like `5% * 80kg = 400 kg %` (changes to give correct result of `4 kg`.
Rule two fixes case like "5% * 5% = 25%^2" (changes to give correct result of `0.25%`)

### Ambiguous case
With the above rules, there is still one ambiguous case: `5% * 100`

Should it be parsed as "5% of 100" (giving 5) or as "100 time 5% (giving 500%).
The current rules parse it as the latter, which may be unexpected.

It is not really possible to adjust the simplify function to give the result "5". At that point the internal value is already 500%, and stripping the percentage here would just strip all percentages.

### Proposal to overload `of`
I propose overloading the `of` operator specifically to handle this case with percentages. We would have `5% of 100 == 5`, while multiplication would give `500%`. This would clear up any ambiguity (although I would probably file a separate issue/PR).

It should not cause issues with any other operations, since it would only activate when a percentage is on the left-side of the of operator (similar to how string concat is special-cased in many languages).

## Problems
- [x] Fix current test failures
   - Probably need to move conversion logic from `mul` -> `simplify`
- [x] Add new tests for new behavior
    - I re-enabled the `five_percent_times_five_percent` test which was previously marked as `#[ignore]`
- [x] Remove `dbg!` statements
- [ ] Consider "ambiguous case" I brought up (not a blocker)
- [ ] Documentation on wiki?

Fixes issue #164
