### PR TITLE
Use workspace inheritance to simplify cargo config

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,19 @@
 [workspace]
 members = ["cli", "core", "wasm"]
 
+[workspace.package]
+version = "1.1.1"
+description = "Arbitrary-precision unit-aware calculator"
+edition = "2021"
+homepage = "https://github.com/printfn/fend"
+repository = "https://github.com/printfn/fend"
+keywords = ["calculator", "cli", "conversion", "math", "tool"]
+categories = ["command-line-utilities", "mathematics", "science"]
+license = "MIT"
+
+[workspace.dependencies]
+fend-core = { version = "1.1.1", path = "core" }
+
 [profile.release]
 lto = true
 opt-level = "z" # small code size

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,21 +1,20 @@
 [package]
 name = "fend"
-# Don't bump version numbers manually, use deploy.sh instead
-version = "1.1.1"
-description = "Arbitrary-precision unit-aware calculator"
-homepage = "https://github.com/printfn/fend"
-repository = "https://github.com/printfn/fend"
+version.workspace = true
+description.workspace = true
+edition.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
+license.workspace = true
 readme = "../README.md"
-license = "MIT"
-keywords = ["calculator", "cli", "conversion", "math", "tool"]
-edition = "2021"
-categories = ["command-line-utilities", "mathematics", "science"]
 
 [dependencies]
 atty = "0.2.14"
 console = { version = "0.15.1", default-features = false }
 ctrlc = "3.2.3"
-fend-core = { version = "1.1.1", path = "../core" }
+fend-core.workspace = true
 home = "0.5.3"
 nanorand = { version = "0.6.1", default-features = false, features = ["std", "wyrand"] }
 rustyline = { version =  "10.0.2", default-features = false, package = "rustyline-with-hint-fix" }

--- a/contrib/deploy.sh
+++ b/contrib/deploy.sh
@@ -112,23 +112,13 @@ fi
 
 echo "Bumping version numbers..."
 
-# version number in fend-core
+# fend workspace Cargo.toml x2
 sed "s/^version = \"$OLD_VERSION\"$/version = \"$NEW_VERSION\"/" \
-    core/Cargo.toml >temp
-mv temp core/Cargo.toml
-
-# fend cli TOML x2
-sed "s/^version = \"$OLD_VERSION\"$/version = \"$NEW_VERSION\"/" \
-    cli/Cargo.toml | \
+    Cargo.toml | \
     sed "s/^fend-core = { version = \"$OLD_VERSION\"/fend-core = { version = \"$NEW_VERSION\"/" >temp
-mv temp cli/Cargo.toml
+mv temp Cargo.toml
 
-# wasm TOML
-sed "s/^version = \"$OLD_VERSION\"$/version = \"$NEW_VERSION\"/" \
-    wasm/Cargo.toml >temp
-mv temp wasm/Cargo.toml
-
-gitdiff "" 7 7
+gitdiff "" 3 3
 
 manualstep "Add changelog to CHANGELOG.md"
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "fend-core"
-version = "1.1.1"
-description = "Arbitrary-precision unit-aware calculator"
-homepage = "https://github.com/printfn/fend"
-repository = "https://github.com/printfn/fend"
+version.workspace = true
+description.workspace = true
+edition.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
+license.workspace = true
 readme = "README.md"
-license = "MIT"
-keywords = ["calculator", "library", "conversion", "math", "tool"]
-edition = "2021"
-categories = ["command-line-utilities", "mathematics", "science"]
 
 [dependencies]

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -1,10 +1,15 @@
 [package]
 name = "fend-wasm"
-version = "1.1.1"
-edition = "2021"
-license = "MIT"
-repository = "https://github.com/printfn/fend"
+version.workspace = true
+# `description`, `homepage`, `repository` and `license` can't be
+# from the workspace root due to wasm-pack bug #1180
 description = "Arbitrary-precision unit-aware calculator"
+edition.workspace = true
+homepage = "https://github.com/printfn/fend"
+repository = "https://github.com/printfn/fend"
+keywords.workspace = true
+categories.workspace = true
+license = "MIT"
 publish = false
 
 [lib]
@@ -15,7 +20,7 @@ crate-type = ["cdylib", "rlib"]
 default = []
 
 [dependencies]
-fend-core = { path = "../core" }
+fend-core.workspace = true
 instant = { version = "0.1.12", features = [ "wasm-bindgen" ] }
 js-sys = "0.3.60"
 wasm-bindgen = "0.2.83"


### PR DESCRIPTION
This will bump the minimum required Rust version to 1.64.

- [ ] `wasm-pack` is fixed ([issue](https://github.com/rustwasm/wasm-pack/issues/1180))
- [x] Available on Homebrew
- [x] Available on Arch Linux
- [x] Available on NixOS ([tracker](https://nixpk.gs/pr-tracker.html?pr=192485))