### PR TITLE
Add cup, tablespoon (tbsp) and teaspoon (tsp)

### DIFF
--- a/core/src/units/builtin.rs
+++ b/core/src/units/builtin.rs
@@ -536,12 +536,17 @@ const LIQUID_UNITS: &[UnitTuple] = &[
     ("gal", "", "gallon", ""),
     ("quart", "quarts", "1/4 gallon", ""),
     ("pint", "pints", "1/2 quart", ""),
+    ("cup", "cups", "1/2 pint", ""),
     ("gill", "", "1/4 pint", ""),
     ("fluid_ounce", "", "1/16 pint", ""),
+    ("tablespoon", "tablespoons", "1/2 floz", ""),
+    ("teaspoon", "teaspoons", "1/3 tablespoon", ""),
     ("fluid_dram", "", "1/8 floz", ""),
     ("qt", "", "quart", ""),
     ("pt", "", "pint", ""),
     ("floz", "", "fluid_ounce", ""),
+    ("tbsp", "", "tablespoon", ""),
+    ("tsp", "", "teaspoon", ""),
 ];
 
 const AVOIRDUPOIS_WEIGHT: &[UnitTuple] = &[


### PR DESCRIPTION
My attempt at a fix for https://github.com/printfn/fend/issues/208.

I have naïvely added these units by analogy from the others in the file. I have not built or tested these changes, but logically (to me!) they should work.