### PR TITLE
add bin alias for binary

### DIFF
--- a/core/src/ast.rs
+++ b/core/src/ast.rs
@@ -639,7 +639,7 @@ pub(crate) fn resolve_identifier<I: Interrupt>(
         "base" => Value::BuiltInFunction(BuiltInFunction::Base),
         "dec" | "decimal" => Value::Base(Base::from_plain_base(10)?),
         "hex" | "hexadecimal" => Value::Base(Base::from_plain_base(16)?),
-        "binary" => Value::Base(Base::from_plain_base(2)?),
+        "bin" | "binary" => Value::Base(Base::from_plain_base(2)?),
         "ternary" => Value::Base(Base::from_plain_base(3)?),
         "senary" | "seximal" => Value::Base(Base::from_plain_base(6)?),
         "oct" | "octal" => Value::Base(Base::from_plain_base(8)?),


### PR DESCRIPTION
there are already 3-letter aliases for hex -> hexadecimal and dec -> decimal, this adds one for binary

passes cargo fmt, clippy, and tests