### PR TITLE
Change the exchange rate handler to a trait, implemented for `Fn`.

### DIFF
--- a/core/src/units.rs
+++ b/core/src/units.rs
@@ -36,12 +36,12 @@ fn expr_unit<I: Interrupt>(
     let (singular, plural, definition) = unit_def;
     let mut definition = definition.trim();
     if definition == "$CURRENCY" {
-        let Some(exchange_rate_fn) = context.get_exchange_rate else {
+        let Some(exchange_rate_fn) = &context.get_exchange_rate else {
             return Err(FendError::NoExchangeRatesAvailable);
         };
-        let one_usd_in_currency = exchange_rate_fn(singular)?;
+        let one_base_in_currency = exchange_rate_fn.relative_to_base_currency(singular)?;
         let value = evaluate_to_value(
-            format!("(1/{one_usd_in_currency}) BASE_CURRENCY").as_str(),
+            format!("(1/{one_base_in_currency}) BASE_CURRENCY").as_str(),
             None,
             attrs,
             context,


### PR DESCRIPTION
This allows for much greater flexibility and much less global state.

~~I also edited `fend` itself to use this, but it still uses a little `thread_local!`, because otherwise there'd be a breaking API change.~~

Couldn't get it to work