### PR TITLE
Add "zł" as alias for PLN

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -491,6 +491,7 @@ pub mod test_utils {
 			"NZD" => 1.5,
 			"HKD" => 8.0,
 			"AUD" => 1.3,
+			"PLN" => 0.2,
 			_ => panic!("unknown currency {currency}"),
 		})
 	}

--- a/core/src/units/builtin.rs
+++ b/core/src/units/builtin.rs
@@ -630,6 +630,7 @@ const CURRENCIES: &[UnitTuple] = &[
 	("AU$", "AU$", "AUD", ""),
 	("HK$", "HK$", "HKD", ""),
 	("NZ$", "NZ$", "NZD", ""),
+	("zł", "zł", "PLN", ""), // the local abbreviation for PLN, see https://en.wikipedia.org/wiki/Polish_z%C5%82oty
 ];
 
 // from https://en.wikipedia.org/wiki/ISO_4217


### PR DESCRIPTION
Add the local abbreviation for PLN. The full name won't be grammatically correct because they have multiple forms e.g. "1 złoty", "2 złote", "5 złotych", "100 złotych". The same goes for "grosz", where 1 grosz = 0.1 złoty. The abbreviation here would also conflict with grams since it's "gr". Nonetheless, having "zł" would be nice to have for Polish people.

The abbreviation is unambiguous and does not seem to conflict with other unit names https://duckduckgo.com/?q=z%C5%82

See:
https://en.wikipedia.org/wiki/Polish_z%C5%82oty