### PR TITLE
Use UN treasury data for currency exchange rates

### DIFF
--- a/cli/src/context.rs
+++ b/cli/src/context.rs
@@ -61,10 +61,9 @@ impl<'a> Context<'a> {
 		let mut ctx_borrow = self.ctx.borrow_mut();
 		ctx_borrow.core_ctx.set_random_u32_fn(random_u32);
 		ctx_borrow.core_ctx.set_output_mode_terminal();
-		let exchange_rate_handler = if config.enable_internet_access {
-			exchange_rates::exchange_rate_handler
-		} else {
-			|_: &str| Err(exchange_rates::InternetAccessDisabledError.into())
+		let exchange_rate_handler = exchange_rates::ExchangeRateHandler {
+			enable_internet_access: config.enable_internet_access,
+			source: config.exchange_rate_source,
 		};
 		ctx_borrow
 			.core_ctx

--- a/cli/src/default_config.toml
+++ b/cli/src/default_config.toml
@@ -27,6 +27,15 @@ unknown-settings = 'warn'
 # exchange rates.
 enable-internet-access = true
 
+# Data source for currency exchange rates. fend supports
+# the following options:
+#   * `UN` retrieves data from the UN treasury
+#     (endpoint: https://treasury.un.org/operationalrates/xsql2XML.php)
+#   * `EU` retrieves data from the EU central bank
+#     (endpoint: https://www.ecb.europa.eu/stats/eurofxref/eurofxref-daily.xml)
+#   * 'disabled' will disable loading of exchange rate data
+exchange-rate-source = "UN"
+
 # This section controls the colors that are used by
 # fend. Make sure the `enable-colors` setting is
 # turned on for this to work.

--- a/cli/src/exchange_rates.rs
+++ b/cli/src/exchange_rates.rs
@@ -1,3 +1,4 @@
+use crate::config::{self, ExchangeRateSource};
 use crate::file_paths;
 use crate::Error;
 use std::{error, fmt, fs, io::Write, time};
@@ -10,9 +11,17 @@ fn get_current_timestamp() -> Result<u64, Error> {
 		.as_secs())
 }
 
-fn load_cached_data() -> Result<String, Error> {
+fn get_cache_filename(source: config::ExchangeRateSource) -> Result<&'static str, Error> {
+	Ok(match source {
+		ExchangeRateSource::Disabled => return Err(ExchangeRateSourceDisabledError.into()),
+		ExchangeRateSource::EuropeanUnion => "eurofxref-daily.xml.cache",
+		ExchangeRateSource::UnitedNations => "xsql2XML.php.cache",
+	})
+}
+
+fn load_cached_data(source: config::ExchangeRateSource) -> Result<String, Error> {
 	let mut cache_file = file_paths::get_cache_dir(file_paths::DirMode::DontCreate)?;
-	cache_file.push("eurofxref-daily.xml.cache");
+	cache_file.push(get_cache_filename(source)?);
 	let cache_contents = fs::read_to_string(cache_file)?;
 	let (timestamp, cache_xml) =
 		cache_contents.split_at(cache_contents.find(';').ok_or("invalid cache file")?);
@@ -27,9 +36,9 @@ fn load_cached_data() -> Result<String, Error> {
 	Ok(cache_xml.to_string())
 }
 
-fn store_cached_data(xml: &str) -> Result<(), Error> {
+fn store_cached_data(source: config::ExchangeRateSource, xml: &str) -> Result<(), Error> {
 	let mut cache_file = file_paths::get_cache_dir(file_paths::DirMode::Create)?;
-	cache_file.push("eurofxref-daily.xml.cache");
+	cache_file.push(get_cache_filename(source)?);
 	let mut file = fs::File::create(cache_file)?;
 	write!(file, "{};{xml}", get_current_timestamp()?)?;
 	Ok(())
@@ -52,18 +61,62 @@ fn ureq_get(_url: &str) -> Result<String, Error> {
 	Err("internet access has been disabled in this build of fend".into())
 }
 
-fn load_exchange_rate_xml() -> Result<(String, bool), Error> {
-	match load_cached_data() {
+fn load_exchange_rate_xml(source: config::ExchangeRateSource) -> Result<(String, bool), Error> {
+	match load_cached_data(source) {
 		Ok(xml) => return Ok((xml, true)),
 		Err(_e) => {
-			//eprintln!("failed to load cached data: {_e}");
+			// failed to load cached data
 		}
 	}
-	let xml = ureq_get("https://treasury.un.org/operationalrates/xsql2XML.php")?;
+	let url = match source {
+		ExchangeRateSource::Disabled => return Err(ExchangeRateSourceDisabledError.into()),
+		ExchangeRateSource::EuropeanUnion => {
+			"https://www.ecb.europa.eu/stats/eurofxref/eurofxref-daily.xml"
+		}
+		ExchangeRateSource::UnitedNations => {
+			"https://treasury.un.org/operationalrates/xsql2XML.php"
+		}
+	};
+	let xml = ureq_get(url)?;
 	Ok((xml, false))
 }
 
-fn parse_exchange_rates(exchange_rates: &str) -> Result<Vec<(String, f64)>, Error> {
+fn parse_exchange_rates(
+	source: config::ExchangeRateSource,
+	exchange_rates: &str,
+) -> Result<Vec<(String, f64)>, Error> {
+	match source {
+		ExchangeRateSource::Disabled => Err(ExchangeRateSourceDisabledError.into()),
+		ExchangeRateSource::EuropeanUnion => parse_exchange_rates_eu(exchange_rates),
+		ExchangeRateSource::UnitedNations => parse_exchange_rates_un(exchange_rates),
+	}
+}
+
+fn parse_exchange_rates_eu(exchange_rates: &str) -> Result<Vec<(String, f64)>, Error> {
+	let err = "failed to load exchange rates";
+	let mut result = vec![("EUR".to_string(), 1.0)];
+	for l in exchange_rates.lines() {
+		let l = l.trim();
+		if !l.starts_with("<Cube currency=") {
+			continue;
+		}
+		let l = l.strip_prefix("<Cube currency='").ok_or(err)?;
+		let (currency, l) = l.split_at(3);
+		let l = l.trim_start_matches("' rate='");
+		let exchange_rate_eur = l.split_at(l.find('\'').ok_or(err)?).0;
+		let exchange_rate_eur = exchange_rate_eur.parse::<f64>()?;
+		if !exchange_rate_eur.is_normal() {
+			return Err(err.into());
+		}
+		result.push((currency.to_string(), exchange_rate_eur));
+	}
+	if result.len() < 10 {
+		return Err(err.into());
+	}
+	Ok(result)
+}
+
+fn parse_exchange_rates_un(exchange_rates: &str) -> Result<Vec<(String, f64)>, Error> {
 	const F_CURR_LEN: usize = "<f_curr_code>".len();
 	const RATE_LEN: usize = "<rate>".len();
 
@@ -105,11 +158,11 @@ fn parse_exchange_rates(exchange_rates: &str) -> Result<Vec<(String, f64)>, Erro
 	Ok(result)
 }
 
-fn get_exchange_rates() -> Result<Vec<(String, f64)>, Error> {
-	let (xml, cached) = load_exchange_rate_xml()?;
-	let parsed_data = parse_exchange_rates(&xml)?;
+fn get_exchange_rates(source: config::ExchangeRateSource) -> Result<Vec<(String, f64)>, Error> {
+	let (xml, cached) = load_exchange_rate_xml(source)?;
+	let parsed_data = parse_exchange_rates(source, &xml)?;
 	if !cached {
-		store_cached_data(&xml)?;
+		store_cached_data(source, &xml)?;
 	}
 	Ok(parsed_data)
 }
@@ -135,12 +188,35 @@ impl fmt::Display for InternetAccessDisabledError {
 
 impl error::Error for InternetAccessDisabledError {}
 
-pub fn exchange_rate_handler(currency: &str) -> Result<f64, Error> {
-	let exchange_rates = get_exchange_rates()?;
-	for (c, rate) in exchange_rates {
-		if currency == c {
-			return Ok(rate);
-		}
+#[derive(Copy, Clone, Debug)]
+pub struct ExchangeRateSourceDisabledError;
+impl fmt::Display for ExchangeRateSourceDisabledError {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		write!(f, "exchange rate source is set to `disabled`")
 	}
-	Err(UnknownExchangeRate(currency.to_string()))?
+}
+
+impl error::Error for ExchangeRateSourceDisabledError {}
+
+pub struct ExchangeRateHandler {
+	pub enable_internet_access: bool,
+	pub source: ExchangeRateSource,
+}
+
+impl fend_core::ExchangeRateFn for ExchangeRateHandler {
+	fn relative_to_base_currency(
+		&self,
+		currency: &str,
+	) -> Result<f64, Box<dyn std::error::Error + Send + Sync + 'static>> {
+		if !self.enable_internet_access {
+			return Err(InternetAccessDisabledError.into());
+		}
+		let exchange_rates = get_exchange_rates(self.source)?;
+		for (c, rate) in exchange_rates {
+			if currency == c {
+				return Ok(rate);
+			}
+		}
+		Err(UnknownExchangeRate(currency.to_string()).into())
+	}
 }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -164,10 +164,12 @@ enum OutputMode {
 /// An exchange rate handler.
 pub trait ExchangeRateFn {
 	/// Returns the value of a currency relative to the base currency.
-	/// The base currency depends on your implementation; the core does not depend on your decision at all, as long as its consistent.
+	/// The base currency depends on your implementation. fend-core can work
+	/// with any base currency as long as it is consistent.
 	///
 	/// # Errors
-	/// This function errors out if the currency was not found or the conversion is impossible for any reason (HTTP request failed, etc.)
+	/// This function errors out if the currency was not found or the
+	/// conversion is impossible for any reason (HTTP request failed, etc.)
 	fn relative_to_base_currency(
 		&self,
 		currency: &str,


### PR DESCRIPTION
Closes #238
This uses a loose parser similarly to the previous implementation although a proper xml parser is probably better.