### PR TITLE
Add exchange rate data to web

### DIFF
--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -1,13 +1,11 @@
-#![allow(unused_unsafe)]
-
 use instant::Instant;
 use std::cell::RefCell;
-use std::collections::BTreeMap;
+use std::collections::HashMap;
 use std::fmt::Write;
 use std::{error, fmt};
 use wasm_bindgen::prelude::*;
 
-thread_local!(static CURRENCY_DATA: RefCell<BTreeMap<String, f64>> = RefCell::new(BTreeMap::new()));
+thread_local!(static CURRENCY_DATA: RefCell<HashMap<String, f64>> = RefCell::new(HashMap::new()));
 
 struct TimeoutInterrupt {
 	start: Instant,
@@ -53,7 +51,7 @@ pub fn evaluate_fend_with_timeout_2(input: &str, timeout: u32) -> String {
 }
 
 fn random_u32() -> u32 {
-	let random_f64 = unsafe { js_sys::Math::random() };
+	let random_f64 = js_sys::Math::random();
 	(random_f64 * f64::from(u32::MAX)) as u32
 }
 

--- a/web/widget.js
+++ b/web/widget.js
@@ -194,6 +194,32 @@ async function getExchangeRates() {
   return map;
 }
 
+async function getExchangeRates() {
+    const map = new Map();
+
+    try {
+        const res = await fetch(
+            `https://corsproxy.io/?${encodeURIComponent(
+                "https://treasury.un.org/operationalrates/xsql2XML.php",
+            )
+            }`,
+        );
+        const xml = await res.text();
+        const dom = new DOMParser().parseFromString(xml, "text/xml");
+
+        dom.querySelectorAll("UN_OPERATIONAL_RATES").forEach((node) => {
+            const currency = node.querySelector("f_curr_code").textContent;
+            const rate = parseFloat(node.querySelector("rate").textContent);
+
+            if (!Number.isNaN(rate) && Number.isFinite(rate)) {
+                map.set(currency, rate);
+            }
+        });
+    } catch (_) { }
+
+    return map;
+}
+
 async function load() {
   await wasm_bindgen("./pkg/fend_wasm_bg.wasm");
   initialiseWithHandlers(await getExchangeRates());

--- a/web/widget.js
+++ b/web/widget.js
@@ -1,4 +1,9 @@
-const { initialise, evaluateFendWithTimeout, evaluateFendWithVariablesJson } = wasm_bindgen;
+const {
+  initialise,
+  initialiseWithHandlers,
+  evaluateFendWithTimeout,
+  evaluateFendWithVariablesJson,
+} = wasm_bindgen;
 
 const EVALUATE_KEY = 13;
 const NAVIGATE_UP_KEY = 38;
@@ -13,159 +18,193 @@ let variables = "";
 let navigation = 0;
 
 async function evaluate(event) {
-    // allow multiple lines to be entered if shift, ctrl
-    // or meta is held, otherwise evaluate the expression
-    if (!(event.keyCode == EVALUATE_KEY && !event.shiftKey && !event.ctrlKey && !event.metaKey)) {
-        return;
-    }
+  // allow multiple lines to be entered if shift, ctrl
+  // or meta is held, otherwise evaluate the expression
+  if (
+    !(event.keyCode == EVALUATE_KEY && !event.shiftKey && !event.ctrlKey &&
+      !event.metaKey)
+  ) {
+    return;
+  }
 
-    event.preventDefault();
+  event.preventDefault();
 
-    if (inputText.value == "clear") {
-        output.innerHTML = "";
-        inputText.value = "";
-        inputHint.innerText = "";
-        return;
-    }
-
-    let request = document.createElement("p");
-    let result = document.createElement("p");
-
-    request.innerText = "> " + inputText.value;
-
-    if (isInputFilled()) {
-        history.push(inputText.value);
-    }
-
-    navigateEnd();
-
-    const fendResult = JSON.parse(evaluateFendWithVariablesJson(inputText.value, 500, variables));
-
+  if (inputText.value == "clear") {
+    output.innerHTML = "";
     inputText.value = "";
     inputHint.innerText = "";
+    return;
+  }
 
-    console.log(fendResult);
+  let request = document.createElement("p");
+  let result = document.createElement("p");
 
-    result.innerText = fendResult.ok ? fendResult.result : fendResult.message;
-    if (fendResult.ok && fendResult.variables.length > 0) {
-        variables = fendResult.variables;
-    }
+  request.innerText = "> " + inputText.value;
 
-    output.appendChild(request);
-    output.appendChild(result);
+  if (isInputFilled()) {
+    history.push(inputText.value);
+  }
 
-    inputHint.scrollIntoView();
+  navigateEnd();
+
+  const fendResult = JSON.parse(
+    evaluateFendWithVariablesJson(inputText.value, 500, variables),
+  );
+
+  inputText.value = "";
+  inputHint.innerText = "";
+
+  console.log(fendResult);
+
+  result.innerText = fendResult.ok ? fendResult.result : fendResult.message;
+  if (fendResult.ok && fendResult.variables.length > 0) {
+    variables = fendResult.variables;
+  }
+
+  output.appendChild(request);
+  output.appendChild(result);
+
+  inputHint.scrollIntoView();
 }
 
 function navigate(event) {
-    if (![NAVIGATE_UP_KEY, NAVIGATE_DOWN_KEY].includes(event.keyCode)) {
-        return;
+  if (![NAVIGATE_UP_KEY, NAVIGATE_DOWN_KEY].includes(event.keyCode)) {
+    return;
+  }
+  if (navigation > 0) {
+    if (NAVIGATE_UP_KEY == event.keyCode) {
+      event.preventDefault();
+
+      navigateBackwards();
+    } else if (NAVIGATE_DOWN_KEY == event.keyCode) {
+      event.preventDefault();
+
+      navigateForwards();
     }
-    if (navigation > 0) {
-        if (NAVIGATE_UP_KEY == event.keyCode) {
-            event.preventDefault();
+  } else if (
+    !isInputFilled() && history.length > 0 && NAVIGATE_UP_KEY == event.keyCode
+  ) {
+    event.preventDefault();
 
-            navigateBackwards();
-        }
+    navigateBegin();
+  }
 
-        else if (NAVIGATE_DOWN_KEY == event.keyCode) {
-            event.preventDefault();
+  if (navigation > 0) {
+    navigateSet();
+  }
 
-            navigateForwards();
-        }
-
-    } else if (!isInputFilled() && history.length > 0 && NAVIGATE_UP_KEY == event.keyCode) {
-        event.preventDefault();
-
-        navigateBegin();
-    }
-
-    if (navigation > 0) {
-        navigateSet();
-    }
-
-    updateReplicatedText();
-    updateHint();
+  updateReplicatedText();
+  updateHint();
 }
 
 function navigateBackwards() {
-    navigation += 1;
+  navigation += 1;
 
-    if (navigation > history.length) {
-        navigation = history.length;
-    }
+  if (navigation > history.length) {
+    navigation = history.length;
+  }
 }
 
 function navigateForwards() {
-    navigation -= 1;
+  navigation -= 1;
 
-    if (navigation < 1) {
-        navigateEnd();
-        navigateClear();
-    }
+  if (navigation < 1) {
+    navigateEnd();
+    navigateClear();
+  }
 }
 
 function navigateBegin() {
-    navigation = 1;
+  navigation = 1;
 }
 
 function navigateEnd() {
-    navigation = 0;
+  navigation = 0;
 }
 
 function navigateSet() {
-    inputText.value = history[history.length - navigation];
+  inputText.value = history[history.length - navigation];
 }
 
 function navigateClear() {
-    inputText.value = "";
+  inputText.value = "";
 }
 
 function focus() {
-    // allow the user to select text for copying and
-    // pasting, but if text is deselected (collapsed)
-    // refocus the input field
-    if (document.activeElement != inputText && document.getSelection().isCollapsed) {
-        inputText.focus();
-    }
+  // allow the user to select text for copying and
+  // pasting, but if text is deselected (collapsed)
+  // refocus the input field
+  if (
+    document.activeElement != inputText && document.getSelection().isCollapsed
+  ) {
+    inputText.focus();
+  }
 }
 
 async function update() {
-    updateReplicatedText();
-    navigateEnd();
-    updateHint();
+  updateReplicatedText();
+  navigateEnd();
+  updateHint();
 }
 
 function updateReplicatedText() {
-    inputText.parentNode.dataset.replicatedValue = inputText.value;
+  inputText.parentNode.dataset.replicatedValue = inputText.value;
 }
 
 function updateHint() {
-    const result = JSON.parse(evaluateFendWithVariablesJson(inputText.value, 100, variables));
+  const result = JSON.parse(
+    evaluateFendWithVariablesJson(inputText.value, 100, variables),
+  );
 
-    if (result.ok) {
-        inputHint.innerText = result.result;
-    } else {
-        inputHint.innerText = "";
-    }
+  if (result.ok) {
+    inputHint.innerText = result.result;
+  } else {
+    inputHint.innerText = "";
+  }
 }
 
 function isInputFilled() {
-    return inputText.value.length > 0;
+  return inputText.value.length > 0;
+}
+
+async function getExchangeRates() {
+  const map = new Map();
+
+  try {
+    const res = await fetch(
+      `https://corsproxy.io/?${
+        encodeURIComponent(
+          "https://treasury.un.org/operationalrates/xsql2XML.php",
+        )
+      }`,
+    );
+    const xml = await res.text();
+    const dom = new DOMParser().parseFromString(xml, "text/xml");
+
+    dom.querySelectorAll("UN_OPERATIONAL_RATES").forEach((node) => {
+      const currency = node.querySelector("f_curr_code").textContent;
+      const rate = parseFloat(node.querySelector("rate").textContent);
+
+      if (!Number.isNaN(rate) && Number.isFinite(rate)) {
+        map.set(currency, rate);
+      }
+    });
+  } catch (_) {}
+
+  return map;
 }
 
 async function load() {
-    await wasm_bindgen('./pkg/fend_wasm_bg.wasm');
+  await wasm_bindgen("./pkg/fend_wasm_bg.wasm");
+  initialiseWithHandlers(await getExchangeRates());
 
-    initialise();
+  evaluateFendWithTimeout("1 + 2", 500);
+  wasmInitialised = true;
 
-    evaluateFendWithTimeout("1 + 2", 500);
-    wasmInitialised = true;
-
-    inputText.addEventListener('input', update);
-    inputText.addEventListener('keypress', evaluate);
-    inputText.addEventListener('keydown', navigate);
-    document.addEventListener('click', focus)
-};
+  inputText.addEventListener("input", update);
+  inputText.addEventListener("keypress", evaluate);
+  inputText.addEventListener("keydown", navigate);
+  document.addEventListener("click", focus);
+}
 
 window.onload = load;


### PR DESCRIPTION
Closes #167, together with #175 

Using [https://corsproxy.io](https://corsproxy.io), the website downloads the latest exchange rate data from the [UN Treasury](https://treasury.un.org/operationalrates/xsql2XML.php), and initialises fend using `initialiseWithHandlers(data)` 