### PR TITLE
Autogenerate ids for headers in docs

### DIFF
--- a/documentation/add-header-ids.lua
+++ b/documentation/add-header-ids.lua
@@ -1,0 +1,25 @@
+function generateSlug(el)
+    if el.tag == "Header" then
+        local headerText = pandoc.utils.stringify(el.content)
+        local slug = urlify(headerText)
+        el.attr = { id = slug }
+    end
+    return el
+end
+
+function urlify(text)
+    -- Replace non-alphanumeric characters with hyphens
+    text = text:gsub("[^a-zA-Z0-9]", "-")
+    -- Remove extra hyphens
+    text = text:gsub("-+", "-")
+    -- Remove leading and trailing hyphens
+    text = text:gsub("^%-*(.-)%-*$", "%1")
+    -- Convert to lowercase
+    text = text:lower()
+    return text
+end
+
+-- Apply the filter
+return {
+    { Header = generateSlug }
+}

--- a/web/build.sh
+++ b/web/build.sh
@@ -13,4 +13,5 @@ mkdir -p documentation
     --metadata-file=pandoc-metadata.yml \
     --lua-filter=include-code-files.lua \
     --lua-filter=include-files.lua \
+    --lua-filter=add-header-ids.lua \
     index.md)


### PR DESCRIPTION
Although the docs has a table of contents with links to each section, those links are broken because the headers themselves don't have any id associated with them. This PR fixes this by autogenerating ids using a pandoc filter for the headers.