### PR TITLE
Fix license files

### DIFF
--- a/cli/LICENSE.md
+++ b/cli/LICENSE.md
@@ -1,0 +1,1 @@
+../LICENSE.md

--- a/core/LICENSE.md
+++ b/core/LICENSE.md
@@ -1,0 +1,1 @@
+../LICENSE.md


### PR DESCRIPTION
Hello,

I'm working on packaging fend for Fedora, and an issue about the license files arose.
The license files are not packaged to crates.io, but the license for this project requires it.
This PR fixes that for the two crates that are (AFAIK) shared to crates.io.

Thanks
