### PR TITLE
Add metasearch2 to projects using fend in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ These are some projects making use of fend:
 
 * [MicroPad](https://getmicropad.com)
 * [Fendesk](https://github.com/SekoiaTree/fendesk)
+* [metasearch2](https://github.com/mat-1/metasearch2)
 
 Feel free to make a pull request to add your own!
 


### PR DESCRIPTION
I've been using fend to power the calculator in my personal metasearch engine and I've been very happy with it. Here's the part of my code that calls fend: https://github.com/mat-1/metasearch2/blob/master/src/engines/answer/calc.rs