### PR TITLE
Support ¥ symbol for JPY

### DIFF
--- a/core/src/ident.rs
+++ b/core/src/ident.rs
@@ -24,7 +24,7 @@ impl Ident {
 	pub(crate) fn is_prefix_unit(&self) -> bool {
 		// when changing this also make sure to change number output formatting
 		// lexer identifier splitting
-		self.0 == "$" || self.0 == "\u{a3}"
+		["$", "\u{a3}", "\u{a5}"].contains(&&*self.0)
 	}
 
 	pub(crate) fn serialize(&self, write: &mut impl io::Write) -> FResult<()> {

--- a/core/src/lexer.rs
+++ b/core/src/lexer.rs
@@ -393,7 +393,7 @@ fn is_valid_in_ident(ch: char, prev: Option<char>) -> bool {
 		'㏌', '㏏', '㏐', '㏓', '㏔', '㏕', '㏖', '㏗', '㏙', '㏛', '㏜', '㏝',
 	];
 	let only_valid_by_themselves = ['%', '‰', '‱', '′', '″', '’', '”', 'π'];
-	let split_on_subsequent_digit = ['$', '£'];
+	let split_on_subsequent_digit = ['$', '£', '¥'];
 	let always_invalid = ['λ'];
 	if always_invalid.contains(&ch) {
 		false

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -607,6 +607,7 @@ pub mod test_utils {
 			"HKD" => 8.0,
 			"AUD" => 1.3,
 			"PLN" => 0.2,
+			"JPY" => 149.9,
 			_ => panic!("unknown currency {currency}"),
 		})
 	}

--- a/core/src/num/unit.rs
+++ b/core/src/num/unit.rs
@@ -912,7 +912,7 @@ impl FormattedValue {
 				kind: SpanKind::Ident,
 			});
 		}
-		if self.unit_str == "$" || self.unit_str == "\u{a3}" && !attrs.plain_number {
+		if ["$", "\u{a3}", "\u{a5}"].contains(&self.unit_str.as_str()) && !attrs.plain_number {
 			spans.push(Span {
 				string: self.unit_str,
 				kind: SpanKind::Ident,

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -200,7 +200,7 @@ fn parse_apply_cont<'a>(input: &'a [Token], lhs: &Expr) -> ParseResult<'a> {
 				}
 				Expr::Apply(Box::new(lhs.clone()), Box::new(rhs))
 			}
-			// support e.g. '$5' or '£3'
+			// support e.g. '$5', '£3' or '¥10'
 			(Expr::Ident(i), Expr::Literal(Value::Num(_))) if i.is_prefix_unit() => {
 				Expr::Apply(Box::new(lhs.clone()), Box::new(rhs))
 			}

--- a/core/src/units/builtin.rs
+++ b/core/src/units/builtin.rs
@@ -688,7 +688,8 @@ const CURRENCIES: &[UnitTuple] = &[
 	("$", "$", "USD", ""),
 	("euro", "euros", "EUR", ""),
 	("\u{20ac}", "\u{20ac}", "EUR", ""), // Euro symbol
-	("\u{a3}", "\u{a3}", "GBP", ""),
+	("\u{a3}", "\u{a3}", "GBP", ""),     // £
+	("\u{a5}", "\u{a5}", "JPY", ""),     // ¥
 	("AU$", "AU$", "AUD", ""),
 	("HK$", "HK$", "HKD", ""),
 	("NZ$", "NZ$", "NZD", ""),

--- a/core/tests/integration_tests.rs
+++ b/core/tests/integration_tests.rs
@@ -5371,6 +5371,11 @@ fn gbp_symbol() {
 }
 
 #[test]
+fn jpy_symbol() {
+	test_eval("¥5 + ¥3", "¥8");
+}
+
+#[test]
 fn two_statements() {
 	test_eval("2; 4", "4");
 }


### PR DESCRIPTION
I implemented `JPY` as a currency symbol

BEFORE
![image](https://github.com/printfn/fend/assets/53809656/4d404130-bf7f-48b6-9921-3f75926c9c74)

AFTER
![image](https://github.com/printfn/fend/assets/53809656/33f17e2c-4801-40e0-8c22-0794af6d6838)

I also want to implement other currency symbols in this PR. I just couldn't decide to implement them in multiple PRs or all in one. The following is the list of currency i have in my mind.

- [x] Yen Symbol – ¥
- [ ] Franc Symbol – ₣
- [ ] Rupee Symbol – ₹
- [ ] Dinar Symbol – د.ك
- [ ] Dirham Symbol – د.إ
- [ ] Riyal Symbol – ﷼‎
- [ ] Mark Symbol – ₻
- [ ] Ruouble Symbol – ₽
- [ ] Lari Symbol - ₾
- [ ] Lira Symbol - ₺
- [ ] Manat Symbol – ₼
- [ ] Tenge Symbol – ₸
- [ ] Hryvnia Symbol – ₴
- [ ] Spesmilo Symbol – ₷
- [ ] Baht Symbol - ฿
- [ ] Won Symbol – 원
- [ ] Dong Symbol – ₫
- [ ] Tugrik Symbol – ₮
- [ ] Drachma Symbol – ₯
- [ ] Peso Symbol – ₱
- [ ] Austral Symbol – ₳
- [ ] Cedi Symbol – ₵
- [ ] Guarani Symbol – ₲
- [ ] Sheqel Symbol – ₪
- [ ] Penny Symbol – ₰