### PR TITLE
Implement equality check

### DIFF
--- a/core/src/ast.rs
+++ b/core/src/ast.rs
@@ -99,7 +99,7 @@ impl fmt::Display for Bop {
 	}
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) enum Expr {
 	Literal(Value),
 	Ident(Ident),
@@ -122,6 +122,7 @@ pub(crate) enum Expr {
 	Of(Ident, Box<Expr>),
 
 	Assign(Ident, Box<Expr>),
+	Equality(Box<Expr>, Box<Expr>),
 	Statements(Box<Expr>, Box<Expr>),
 }
 
@@ -202,6 +203,11 @@ impl Expr {
 				a.serialize(write)?;
 				b.serialize(write)?;
 			}
+			Self::Equality(a, b) => {
+				16u8.serialize(write)?;
+				a.serialize(write)?;
+				b.serialize(write)?;
+			}
 		}
 		Ok(())
 	}
@@ -249,6 +255,10 @@ impl Expr {
 				Box::new(Self::deserialize(read)?),
 			),
 			15 => Self::Statements(
+				Box::new(Self::deserialize(read)?),
+				Box::new(Self::deserialize(read)?),
+			),
+			16 => Self::Equality(
 				Box::new(Self::deserialize(read)?),
 				Box::new(Self::deserialize(read)?),
 			),
@@ -306,6 +316,11 @@ impl Expr {
 			Self::Assign(a, b) => format!("{a} = {}", b.format(attrs, ctx, int)?),
 			Self::Statements(a, b) => format!(
 				"{}; {}",
+				a.format(attrs, ctx, int)?,
+				b.format(attrs, ctx, int)?
+			),
+			Self::Equality(a, b) => format!(
+				"{} == {}",
 				a.format(attrs, ctx, int)?,
 				b.format(attrs, ctx, int)?
 			),
@@ -451,6 +466,12 @@ pub(crate) fn evaluate<I: Interrupt>(
 		Expr::Statements(a, b) => {
 			let _lhs = evaluate(*a, scope.clone(), attrs, context, int)?;
 			evaluate(*b, scope, attrs, context, int)?
+		}
+		Expr::Equality(a, b) => {
+			let lhs = evaluate(*a, scope.clone(), attrs, context, int)?;
+			let rhs = evaluate(*b, scope.clone(), attrs, context, int)?;
+
+			Value::Bool(lhs == rhs)
 		}
 	})
 }

--- a/core/src/ast.rs
+++ b/core/src/ast.rs
@@ -474,7 +474,12 @@ pub(crate) fn evaluate<I: Interrupt>(
 			let lhs = evaluate(*a, scope.clone(), attrs, context, int)?;
 			let rhs = evaluate(*b, scope.clone(), attrs, context, int)?;
 
-			Value::Bool(if is_equals { lhs == rhs } else { lhs != rhs })
+			if let (Value::Num(l), Value::Num(r)) = (&lhs, &rhs) {
+				let a = l.clone().sub(*r.clone(), int)?;
+				Value::Bool(if is_equals { a.is_zero() } else { !a.is_zero() })
+			} else {
+				Value::Bool(if is_equals { lhs == rhs } else { lhs != rhs })
+			}
 		}
 	})
 }

--- a/core/src/ident.rs
+++ b/core/src/ident.rs
@@ -5,7 +5,7 @@ use crate::{
 	serialize::{Deserialize, Serialize},
 };
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct Ident(Cow<'static, str>);
 
 impl Ident {

--- a/core/src/lexer.rs
+++ b/core/src/lexer.rs
@@ -38,6 +38,7 @@ pub(crate) enum Symbol {
 	Semicolon,
 	Equals,       // used for assignment
 	DoubleEquals, // used for equality
+	NotEquals,
 	Combination,
 	Permutation,
 }
@@ -67,6 +68,7 @@ impl fmt::Display for Symbol {
 			Self::Semicolon => ";",
 			Self::Equals => "=",
 			Self::DoubleEquals => "==",
+			Self::NotEquals => "!=",
 			Self::Combination => "nCr",
 			Self::Permutation => "nPr",
 		};
@@ -507,7 +509,13 @@ fn parse_symbol(ch: char, input: &mut &str) -> FResult<Token> {
 		'(' => Symbol::OpenParens,
 		')' => Symbol::CloseParens,
 		'+' => Symbol::Add,
-		'!' => Symbol::Factorial,
+		'!' => {
+			if test_next('=') {
+				Symbol::NotEquals
+			} else {
+				Symbol::Factorial
+			}
+		}
 		// unicode minus sign
 		'-' | '\u{2212}' => Symbol::Sub,
 		'*' | '\u{d7}' | '\u{2715}' => {

--- a/core/src/lexer.rs
+++ b/core/src/lexer.rs
@@ -36,7 +36,8 @@ pub(crate) enum Symbol {
 	ShiftLeft,
 	ShiftRight,
 	Semicolon,
-	Equals, // used for assignment
+	Equals,       // used for assignment
+	DoubleEquals, // used for equality
 	Combination,
 	Permutation,
 }
@@ -65,6 +66,7 @@ impl fmt::Display for Symbol {
 			Self::ShiftRight => ">>",
 			Self::Semicolon => ";",
 			Self::Equals => "=",
+			Self::DoubleEquals => "==",
 			Self::Combination => "nCr",
 			Self::Permutation => "nPr",
 		};
@@ -523,6 +525,8 @@ fn parse_symbol(ch: char, input: &mut &str) -> FResult<Token> {
 		'=' => {
 			if test_next('>') {
 				Symbol::Fn
+			} else if test_next('=') {
+				Symbol::DoubleEquals
 			} else {
 				Symbol::Equals
 			}

--- a/core/src/num/dist.rs
+++ b/core/src/num/dist.rs
@@ -13,7 +13,7 @@ use std::{fmt, io};
 use super::real::Real;
 use super::{Base, Exact, FormattingStyle};
 
-#[derive(Clone)]
+#[derive(Clone, PartialEq, Eq)]
 pub(crate) struct Dist {
 	// invariant: probabilities must sum to 1
 	parts: HashMap<Complex, BigRat>,

--- a/core/src/num/unit.rs
+++ b/core/src/num/unit.rs
@@ -25,7 +25,7 @@ use unit_exponent::UnitExponent;
 
 use super::Exact;
 
-#[derive(Clone)]
+#[derive(Clone, PartialEq, Eq)]
 #[allow(clippy::pedantic)]
 pub(crate) struct Value {
 	#[allow(clippy::struct_field_names)]
@@ -982,7 +982,7 @@ impl fmt::Display for FormattedValue {
 	}
 }
 
-#[derive(Clone)]
+#[derive(Clone, PartialEq, Eq)]
 struct Unit {
 	components: Vec<UnitExponent>,
 }

--- a/core/src/num/unit.rs
+++ b/core/src/num/unit.rs
@@ -25,7 +25,7 @@ use unit_exponent::UnitExponent;
 
 use super::Exact;
 
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Clone, Eq)]
 #[allow(clippy::pedantic)]
 pub(crate) struct Value {
 	#[allow(clippy::struct_field_names)]
@@ -35,6 +35,12 @@ pub(crate) struct Value {
 	base: Base,
 	format: FormattingStyle,
 	simplifiable: bool,
+}
+
+impl PartialEq for Value {
+	fn eq(&self, other: &Self) -> bool {
+		self.value == other.value && self.unit == other.unit
+	}
 }
 
 impl Value {

--- a/core/src/num/unit/unit_exponent.rs
+++ b/core/src/num/unit/unit_exponent.rs
@@ -8,7 +8,7 @@ use crate::Interrupt;
 
 use super::{base_unit::BaseUnit, named_unit::NamedUnit};
 
-#[derive(Clone)]
+#[derive(Clone, PartialEq, Eq)]
 pub(crate) struct UnitExponent {
 	pub(crate) unit: NamedUnit,
 	pub(crate) exponent: Complex,

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -468,7 +468,16 @@ fn parse_equality(input: &[Token]) -> ParseResult<'_> {
 	let (lhs, input) = parse_function(input)?;
 	if let Ok(((), remaining)) = parse_fixed_symbol(input, Symbol::DoubleEquals) {
 		let (rhs, remaining) = parse_function(remaining)?;
-		Ok((Expr::Equality(Box::new(lhs), Box::new(rhs)), remaining))
+		Ok((
+			Expr::Equality(true, Box::new(lhs), Box::new(rhs)),
+			remaining,
+		))
+	} else if let Ok(((), remaining)) = parse_fixed_symbol(input, Symbol::NotEquals) {
+		let (rhs, remaining) = parse_function(remaining)?;
+		Ok((
+			Expr::Equality(false, Box::new(lhs), Box::new(rhs)),
+			remaining,
+		))
 	} else {
 		Ok((lhs, input))
 	}

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -464,8 +464,18 @@ fn parse_function(input: &[Token]) -> ParseResult<'_> {
 	Ok((lhs, input))
 }
 
-fn parse_assignment(input: &[Token]) -> ParseResult<'_> {
+fn parse_equality(input: &[Token]) -> ParseResult<'_> {
 	let (lhs, input) = parse_function(input)?;
+	if let Ok(((), remaining)) = parse_fixed_symbol(input, Symbol::DoubleEquals) {
+		let (rhs, remaining) = parse_function(remaining)?;
+		Ok((Expr::Equality(Box::new(lhs), Box::new(rhs)), remaining))
+	} else {
+		Ok((lhs, input))
+	}
+}
+
+fn parse_assignment(input: &[Token]) -> ParseResult<'_> {
+	let (lhs, input) = parse_equality(input)?;
 	if let Ok(((), remaining)) = parse_fixed_symbol(input, Symbol::Equals) {
 		if let Expr::Ident(s) = lhs {
 			let (rhs, remaining) = parse_assignment(remaining)?;

--- a/core/src/scope.rs
+++ b/core/src/scope.rs
@@ -7,7 +7,7 @@ use crate::{ast::Expr, error::Interrupt};
 use std::io;
 use std::sync::Arc;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 enum ScopeValue {
 	//Variable(Value),
 	LazyVariable(Expr, Option<Arc<Scope>>),
@@ -55,7 +55,7 @@ impl ScopeValue {
 	}
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct Scope {
 	ident: Ident,
 	value: ScopeValue,

--- a/core/src/value.rs
+++ b/core/src/value.rs
@@ -18,7 +18,7 @@ pub(crate) mod built_in_function;
 
 use built_in_function::BuiltInFunction;
 
-#[derive(Clone)]
+#[derive(Clone, PartialEq, Eq)]
 pub(crate) enum Value {
 	Num(Box<Number>),
 	BuiltInFunction(BuiltInFunction),

--- a/core/tests/integration_tests.rs
+++ b/core/tests/integration_tests.rs
@@ -5877,5 +5877,7 @@ fn test_superscript() {
 #[test]
 fn test_equality() {
 	test_eval("1 + 2 == 3", "true");
+	test_eval("1 + 2 != 4", "true");
 	test_eval("true == false", "false");
+	test_eval("true != false", "true");
 }

--- a/core/tests/integration_tests.rs
+++ b/core/tests/integration_tests.rs
@@ -5880,4 +5880,5 @@ fn test_equality() {
 	test_eval("1 + 2 != 4", "true");
 	test_eval("true == false", "false");
 	test_eval("true != false", "true");
+	test_eval("2m == 200cm", "true");
 }

--- a/core/tests/integration_tests.rs
+++ b/core/tests/integration_tests.rs
@@ -5873,3 +5873,9 @@ fn test_superscript() {
 	test_eval("200²", "40000");
 	test_eval("13¹³ days", "302875106592253 days");
 }
+
+#[test]
+fn test_equality() {
+	test_eval("1 + 2 == 3", "true");
+	test_eval("true == false", "false");
+}


### PR DESCRIPTION
Potential implementation of #229 
I used the regular rust way of `PartialEq` and `Eq` to check for equality.

![image](https://github.com/printfn/fend/assets/53809656/fc82a36a-cd1f-4260-bd80-1e472ecfe0ef)
