### PR TITLE
Add FendApp to projects using fend

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ These are some projects making use of fend:
 * [MicroPad](https://getmicropad.com)
 * [Fendesk](https://github.com/SekoiaTree/fendesk)
 * [metasearch2](https://github.com/mat-1/metasearch2)
+* [FendApp](https://github.com/JadedBlueEyes/fendapp)
 
 Feel free to make a pull request to add your own!
 


### PR DESCRIPTION
I've been using fend to create a desktop calculator, which I've used myself for the past few months. I thought you might like to see it! 

[
![image](https://github.com/printfn/fend/assets/28905212/defd611e-0044-4b0c-9ffb-07202c4fe00f)
](https://jade.ellis.link/projects/fendapp)