### PR TITLE
Resolve fully-uppercase builtin identifiers

### DIFF
--- a/core/tests/integration_tests.rs
+++ b/core/tests/integration_tests.rs
@@ -5994,3 +5994,14 @@ fn fibonacci() {
 	test_eval("fib 10", "55");
 	test_eval("fib 11", "89");
 }
+
+#[test]
+fn uppercase_identifiers() {
+	test_eval("SIN PI", "0");
+	test_eval("COS TAU", "1");
+	test_eval("LOG 1", "approx. 0");
+	test_eval("LOG10 1", "approx. 0");
+	test_eval("EXP 0", "approx. 1");
+
+	expect_error("foo = 1; FOO", Some("unknown identifier 'FOO'"));
+}


### PR DESCRIPTION
Some users try to use uppercase function names like LOG as they are used to Excel functions, which don't work in fend.

Resolve fully-uppercase builtin identifiers if they are not parsed as units. This ensures that if, for example, "I" becomes a unit in the future, it will be resolved as the unit - not the imaginary number.