### PR TITLE
Keep percentage unit during simplification

### DIFF
--- a/core/src/num/unit/unit_exponent.rs
+++ b/core/src/num/unit/unit_exponent.rs
@@ -40,6 +40,11 @@ impl UnitExponent {
 		self.unit.is_alias()
 	}
 
+	pub(crate) fn is_percentage_unit(&self) -> bool {
+		let (prefix, name) = self.unit.prefix_and_name(false);
+		prefix.is_empty() && ["%", "percent"].contains(&name)
+	}
+
 	pub(crate) fn add_to_hashmap<I: Interrupt>(
 		&self,
 		hashmap: &mut HashMap<BaseUnit, Complex>,

--- a/core/tests/integration_tests.rs
+++ b/core/tests/integration_tests.rs
@@ -2102,22 +2102,22 @@ fn three_meters_15_cm() {
 
 #[test]
 fn five_percent() {
-	test_eval("5%", "0.05");
+	test_eval("5%", "5%");
 }
 
 #[test]
 fn five_percent_to_percent() {
-	test_eval_simple("5% to %", "5%");
+	test_eval("5% to %", "5%");
 }
 
 #[test]
 fn five_percent_plus_point_one() {
-	test_eval("5% + 0.1", "0.15");
+	test_eval("5% + 0.1", "15%");
 }
 
 #[test]
 fn five_percent_plus_one() {
-	test_eval("5% + 1", "1.05");
+	test_eval("5% + 1", "105%");
 }
 
 #[test]
@@ -2132,7 +2132,7 @@ fn one_plus_five_percent() {
 
 #[test]
 fn five_percent_times_five_percent() {
-	test_eval("5% * 5%", "0.0025");
+	test_eval("5% * 5%", "0.25%");
 }
 
 #[test]
@@ -2142,7 +2142,7 @@ fn five_percent_times_kg() {
 
 #[test]
 fn five_percent_times_100() {
-	test_eval("5% * 100", "5");
+	test_eval("5% * 100", "500%");
 }
 
 #[test]
@@ -5221,7 +5221,7 @@ fn single_line_comment_and_linebreak_3() {
 
 #[test]
 fn percent_plus_per_mille() {
-	test_eval("4% + 3\u{2030}", "0.043");
+	test_eval("4% + 3\u{2030}", "4.3%");
 }
 
 #[test]


### PR DESCRIPTION
This is very similar to #165 which fixed #164, which was effectively reverted in ecfe3b3dcc6efac465c62f8bf57f8e1b789c991a.

This maintains the "alias" logic of the latter, but special cases percentages like the former to ensure that percentages are explicitly given with a query like `11/12*100%`.

Explicitly converting to and from percentages is still possible:

```
> 0.5 to %
50%
> 50% to unitless
0.05
```