### PR TITLE
Add new metric prefixes

### DIFF
--- a/core/src/units/builtin.rs
+++ b/core/src/units/builtin.rs
@@ -60,6 +60,7 @@ const BITS_AND_BYTES: &[UnitTuple] = &[
 ];
 
 const STANDARD_PREFIXES: &[UnitTuple] = &[
+	("quetta", "", "lp@1e30", ""),
 	("quecca", "", "lp@1e30", ""),
 	("ronna", "", "lp@1e27", ""),
 	("yotta", "", "lp@1e24", ""),
@@ -780,6 +781,8 @@ const SHORT_PREFIXES: &[(&str, &str)] = &[
 	("Ei", "sp@exbi"),
 	("Zi", "sp@zebi"),
 	("Yi", "sp@yobi"),
+	("Q", "sp@quetta"),
+	("R", "sp@ronna"),
 	("Y", "sp@yotta"),
 	("Z", "sp@zetta"),
 	("E", "sp@exa"),
@@ -802,6 +805,8 @@ const SHORT_PREFIXES: &[(&str, &str)] = &[
 	("a", "sp@atto"),
 	("z", "sp@zepto"),
 	("y", "sp@yocto"),
+	("r", "sp@ronto"),
+	("q", "sp@quecto"),
 ];
 
 #[allow(clippy::too_many_lines)]


### PR DESCRIPTION
- Added 4 [metric symbols](https://en.wikipedia.org/wiki/Metric_prefix#List_of_SI_prefixes) (`Q` for quetta, `q` for quecto, `R` for ronna, and `r` for ronto.)
- Added 'quetta' as an alternate name for 'quecca'