### PR TITLE
Update Arch installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The easiest way to install fend locally is via your package manager:
 | ----------------------- | -------------------------- |
 | Homebrew                | `brew install fend`        |
 | MacPorts                | `sudo port install fend`   |
-| AUR (Arch Linux)        | `yay -Syu aur/fend-bin`    |
+| AUR (Arch Linux)        | `yay -S aur/fend-bin`      |
 | AOSC OS                 | `oma install fend`         |
 | Xbps (Void Linux)       | `xbps-install fend`        |
 | Nix                     | `nix-env -iA nixpkgs.fend` |


### PR DESCRIPTION
Back at it again, as per #330
As I was editing the Readme for #331, I noticed that the recommended command to install fend on Arch would also update the entire system.
As this is not always desired, I removed the `yu` to make the command not also update the entire system.