### PR TITLE
Rework random number generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,7 +128,7 @@ dependencies = [
  "ctrlc",
  "fend-core",
  "minreq",
- "rand",
+ "nanorand",
  "rustyline",
  "serde",
  "toml",
@@ -250,6 +250,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "nanorand"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e3d189da485332e96ba8a5ef646a311871abd7915bf06ac848a9117f19cf6e4"
+
+[[package]]
 name = "native-tls"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -356,15 +362,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
-dependencies = [
- "zerocopy",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -396,35 +393,6 @@ checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
 dependencies = [
  "endian-type",
  "nibble_vec",
-]
-
-[[package]]
-name = "rand"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
-dependencies = [
- "rand_chacha",
- "rand_core",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
- "rand_core",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
-dependencies = [
- "getrandom 0.3.3",
 ]
 
 [[package]]
@@ -882,24 +850,4 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
  "bitflags",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.8.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,4 +18,4 @@ fend-core = { version = "1.5.6", path = "core" }
 [profile.release]
 lto = true
 opt-level = "z" # small code size
- strip = "symbols"
+strip = "symbols"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -13,11 +13,11 @@ readme = "../README.md"
 [dependencies]
 ctrlc = "3.4.7"
 fend-core.workspace = true
-rand = { version = "0.9.1", default-features = false, features = ["thread_rng"] }
 rustyline = { version =  "15.0.0", default-features = false, features = ["with-file-history", "custom-bindings"] }
 serde = { version = "1.0.219", default-features = false }
 toml = { version = "0.8.22", default-features = false, features = ["parse"] }
 minreq = { version = "2.13.4", default-features = false, optional = true }
+nanorand = "0.8.0"
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.59.0", features = ["Win32_Foundation", "Win32_Storage_FileSystem"] }

--- a/cli/src/context.rs
+++ b/cli/src/context.rs
@@ -76,7 +76,7 @@ impl<'a> Context<'a> {
 		int: &impl fend_core::Interrupt,
 	) -> Result<fend_core::FendResult, String> {
 		let mut ctx_borrow = self.ctx.borrow_mut();
-		ctx_borrow.core_ctx.set_random_u32_fn(random_u32);
+		ctx_borrow.core_ctx.set_rng(crate::random::Random::new());
 		ctx_borrow.core_ctx.set_output_mode_terminal();
 		ctx_borrow.core_ctx.set_echo_result(echo_result);
 		ctx_borrow.input_typed = false;
@@ -103,8 +103,4 @@ impl<'a> Context<'a> {
 	pub fn get_input_typed(&self) -> bool {
 		self.ctx.borrow().input_typed
 	}
-}
-
-fn random_u32() -> u32 {
-	rand::random()
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -15,6 +15,7 @@ mod exchange_rates;
 mod file_paths;
 mod helper;
 mod interrupt;
+mod random;
 mod terminal;
 
 use args::Action as ArgsAction;

--- a/cli/src/random.rs
+++ b/cli/src/random.rs
@@ -1,0 +1,18 @@
+use nanorand::{Rng, WyRand};
+
+#[derive(Debug)]
+pub struct Random {
+	rng: WyRand,
+}
+
+impl Random {
+	pub fn new() -> Self {
+		Self { rng: WyRand::new() }
+	}
+}
+
+impl fend_core::Random for Random {
+	fn random_u32(&mut self) -> u32 {
+		self.rng.generate::<u32>()
+	}
+}

--- a/core/src/num/dist.rs
+++ b/core/src/num/dist.rs
@@ -83,15 +83,19 @@ impl Dist {
 	}
 
 	#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-	pub(crate) fn sample<I: Interrupt>(self, ctx: &crate::Context, int: &I) -> FResult<Self> {
+	pub(crate) fn sample<I: Interrupt>(self, ctx: &mut crate::Context, int: &I) -> FResult<Self> {
 		if self.parts.len() == 1 {
 			return Ok(self);
 		}
-		let mut random = ctx.random_u32.ok_or(FendError::RandomNumbersNotAvailable)?();
+		let rng = ctx
+			.rng
+			.as_mut()
+			.ok_or(FendError::RandomNumbersNotAvailable)?;
+		let mut number = rng.random_u32();
 		let mut res = None;
 		for (k, v) in self.parts {
-			random = random.saturating_sub((v.into_f64(int)? * f64::from(u32::MAX)) as u32);
-			if random == 0 {
+			number = number.saturating_sub((v.into_f64(int)? * f64::from(u32::MAX)) as u32);
+			if number == 0 {
 				return Ok(Self::from(k));
 			}
 			res = Some(Self::from(k));

--- a/core/src/num/unit.rs
+++ b/core/src/num/unit.rs
@@ -583,7 +583,7 @@ impl Value {
 		})
 	}
 
-	pub(crate) fn sample<I: Interrupt>(self, ctx: &crate::Context, int: &I) -> FResult<Self> {
+	pub(crate) fn sample<I: Interrupt>(self, ctx: &mut crate::Context, int: &I) -> FResult<Self> {
 		Ok(Self {
 			value: self.value.sample(ctx, int)?,
 			..self

--- a/core/src/random.rs
+++ b/core/src/random.rs
@@ -1,0 +1,5 @@
+/// This trait is fend's RNG.
+pub trait Random: std::fmt::Debug {
+	/// Generate a random u32.
+	fn random_u32(&mut self) -> u32;
+}

--- a/core/tests/integration_tests.rs
+++ b/core/tests/integration_tests.rs
@@ -5488,8 +5488,16 @@ fn coulomb_farad_mode() {
 #[test]
 fn test_rolling_dice() {
 	let mut ctx = Context::new();
-	ctx.set_random_u32_fn(|| 5);
+	ctx.set_rng(Five {});
 	evaluate("roll d20", &mut ctx).unwrap();
+}
+
+#[derive(Debug)]
+struct Five {}
+impl fend_core::Random for Five {
+	fn random_u32(&mut self) -> u32 {
+		5
+	}
 }
 
 #[test]

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -56,9 +56,13 @@ pub fn initialise_with_handlers(currency_data: js_sys::Map) {
 	});
 }
 
-fn random_u32() -> u32 {
-	let random_f64 = js_sys::Math::random();
-	(random_f64 * f64::from(u32::MAX)) as u32
+#[derive(Debug)]
+struct Random {}
+impl fend_core::Random for Random {
+	fn random_u32(&mut self) -> u32 {
+		let random_f64 = js_sys::Math::random();
+		(random_f64 * f64::from(u32::MAX)) as u32
+	}
 }
 
 #[derive(Debug, Clone)]
@@ -100,7 +104,7 @@ fn create_context() -> fend_core::Context {
 		date.get_time() as u64,
 		date.get_timezone_offset() as i64 * 60,
 	);
-	ctx.set_random_u32_fn(random_u32);
+	ctx.set_rng(Random {});
 	if CURRENCY_DATA.get().is_some_and(|x| !x.is_empty()) {
 		ctx.set_exchange_rate_handler_v2(CurrencyHandler);
 	}


### PR DESCRIPTION
Switch core to taking a trait instead of a function
This allows storing RNG data with the Context

Switch cli from rand::rngs::ThreadRng (secure) to nanorand::WyRand (fast)

---

In pyfend, I'm doing the same awkward static thing
https://github.com/raylu/pyfend/blob/a751c056791acd030cf18499d470876de4d6a129/src/lib.rs#L17
as rand is
https://github.com/rust-random/rand/blob/0c955c5b7a079bc2fe67fe946a8deb46c4bc58d8/src/rngs/thread.rs#L158