### PR TITLE
Increase precision for pi

### DIFF
--- a/core/src/num/bigrat.rs
+++ b/core/src/num/bigrat.rs
@@ -253,6 +253,15 @@ impl BigRat {
 		})
 	}
 
+	// cos works for all real numbers
+	pub(crate) fn cos<I: Interrupt>(self, int: &I) -> FResult<Exact<Self>> {
+		Ok(if self == 0.into() {
+			Exact::new(Self::from(1), true)
+		} else {
+			Exact::new(Self::from_f64(f64::cos(self.into_f64(int)?), int)?, false)
+		})
+	}
+
 	// asin, acos and atan only work for values between -1 and 1
 	pub(crate) fn asin<I: Interrupt>(self, int: &I) -> FResult<Self> {
 		let one = Self::from(1);


### PR DESCRIPTION
Instead of a naive division based on the decimal representation of pi, commit 45e2c9e6f2c7b3c19429c6758057498963674925 uses the [Chudnovsky algorithm
](https://en.wikipedia.org/wiki/Chudnovsky_algorithm) to increase the precision of pi.

This algorithm uses a square root in the denominator of each term of the series, namely, `sqrt(640320)`. This value doesn't fit into a rational, and fend must perform a rounding of the exact value at some stage during the computation. This unfortunately introduces a slight imprecision in the computation of pi, big enough though to make the computations of the terms of the series useless after the first one.

The main purpose of this commit is to improve the way pi is handled/computed. The proposed value for pi is based on its continued fraction expansion. More precisely, pi is set here to the (rational) value of its 33th convergent, which diverges from the real value of pi by less than 10^-37 - which is believed to be enough for all practical purposes.
The 33th convergent was found to be the biggest one with both numerator and denominator fitting in a u64 - interesting for performance purposes. 

The previous value (obtained with `pi to fraction`) was correct up to 10^-24 (as can be obtained by asking a computer algebra system, or wolfram alpha).

This better approximation of pi led to the failure of the test
https://github.com/printfn/fend/blob/e2b6b3ee3d9d10436303c1d6dc96af87379ad05d/core/tests/integration_tests.rs#L367
(it returned something like `approx. 0.999999999`), the error was to be traced back to https://github.com/printfn/fend/blob/e2b6b3ee3d9d10436303c1d6dc96af87379ad05d/core/src/num/real.rs#L212
Although mathematically correct, the rounding errors during the conversion made the test fail.

That's why the evaluation of cosines is also modified in the commit (basically, almost a copy/paste of the way sinuses are computed): in order for the test to pass.
I took the opportunity to marginally improve the runtime of the computations of the exact values of sines and cosines (the modulo operation is done only once).