### PR TITLE
fix significant figure rounding

### DIFF
--- a/core/tests/integration_tests.rs
+++ b/core/tests/integration_tests.rs
@@ -4297,6 +4297,16 @@ fn sf_small_2() {
 }
 
 #[test]
+fn sf_rounding_integer_carry() {
+	test_eval("123.9 to 3 sf", "approx. 124");
+}
+
+#[test]
+fn sf_rounding_small_decimal() {
+	test_eval("0.00555 to 2 sf", "approx. 0.0056");
+}
+
+#[test]
 fn sf_small_3() {
 	test_eval("pi / 1000000 to 3 sf", "approx. 0.00000314");
 }


### PR DESCRIPTION
e.g. "12.9 to 2 sf" returns now 13.

Many tests are invalid because they truncate the real result instead of rounding properly.
Somebody has to fix the tests (not me).