### PR TITLE
Add clear command to repl

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -126,6 +126,9 @@ async fn repl_loop(config: &config::Config) -> ExitCode {
 					}
 					Err(e) => eprintln!("{e}"),
 				},
+				"clear" | "clear()" | ":clear" => {
+					print!("\x1b[2J\x1b[H");
+				}
 				line => {
 					interrupt.reset();
 					match eval_and_print_res(line, &mut context, true, &interrupt, config).await {


### PR DESCRIPTION
Simple clear screen implementation. Writing `clear`, `clear()` or `:clear` in the REPL clears the screen.