### PR TITLE
[codex] Add implicit multiplication precedence option

### DIFF
--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -1,4 +1,4 @@
-use fend_core::DecimalSeparatorStyle;
+use fend_core::{DecimalSeparatorStyle, ImplicitMultiplicationPrecedence};
 
 use crate::{color, custom_units::CustomUnitDefinition};
 use std::{env, fmt, fs, io, time};
@@ -15,6 +15,7 @@ pub struct Config {
 	pub exchange_rate_max_age: u64,
 	pub custom_units: Vec<CustomUnitDefinition>,
 	pub decimal_separator: DecimalSeparatorStyle,
+	pub implicit_multiplication_precedence: ImplicitMultiplicationPrecedence,
 	unknown_settings: UnknownSettings,
 	unknown_keys: Vec<String>,
 }
@@ -116,6 +117,7 @@ impl<'de> serde::de::Visitor<'de> for ConfigVisitor {
 		let mut seen_exchange_rate_max_age = false;
 		let mut seen_custom_units = false;
 		let mut seen_decimal_separator_style = false;
+		let mut seen_implicit_multiplication_precedence = false;
 		while let Some(key) = map.next_key::<String>()? {
 			match key.as_str() {
 				"prompt" => {
@@ -222,6 +224,29 @@ impl<'de> serde::de::Visitor<'de> for ConfigVisitor {
 					};
 					seen_decimal_separator_style = true;
 				}
+				"implicit-multiplication-precedence" => {
+					if seen_implicit_multiplication_precedence {
+						return Err(serde::de::Error::duplicate_field(
+							"implicit-multiplication-precedence",
+						));
+					}
+					let precedence: String = map.next_value()?;
+					result.implicit_multiplication_precedence = match precedence.as_str() {
+						"same-as-division" | "default" => {
+							ImplicitMultiplicationPrecedence::SameAsDivision
+						}
+						"higher-than-division" => {
+							ImplicitMultiplicationPrecedence::HigherThanDivision
+						}
+						v => {
+							return Err(serde::de::Error::invalid_value(
+								serde::de::Unexpected::Str(v),
+								&"`default`, `same-as-division` or `higher-than-division`",
+							));
+						}
+					};
+					seen_implicit_multiplication_precedence = true;
+				}
 				unknown_key => {
 					// this may occur if the user has multiple fend versions installed
 					map.next_value::<toml::Value>()?;
@@ -245,6 +270,7 @@ impl<'de> serde::Deserialize<'de> for Config {
 			"enable-internet-access",
 			"custom-units",
 			"decimal-separator-style",
+			"implicit-multiplication-precedence",
 			"exchange-rate-source",
 			"exchange-rate-max-age",
 		];
@@ -266,6 +292,7 @@ impl Default for Config {
 			exchange_rate_max_age: 60 * 60 * 24 * 3,
 			custom_units: vec![],
 			decimal_separator: DecimalSeparatorStyle::Dot,
+			implicit_multiplication_precedence: ImplicitMultiplicationPrecedence::SameAsDivision,
 			unknown_keys: vec![],
 		}
 	}
@@ -350,5 +377,16 @@ mod tests {
 	fn test_default_config_file() {
 		let deserialized: Config = toml::from_str(DEFAULT_CONFIG_FILE).unwrap();
 		assert_eq!(deserialized, Config::default());
+	}
+
+	#[test]
+	fn test_implicit_multiplication_precedence_config() {
+		let deserialized: Config =
+			toml::from_str("implicit-multiplication-precedence = 'higher-than-division'\n")
+				.unwrap();
+		assert_eq!(
+			deserialized.implicit_multiplication_precedence,
+			ImplicitMultiplicationPrecedence::HigherThanDivision
+		);
 	}
 }

--- a/cli/src/context.rs
+++ b/cli/src/context.rs
@@ -50,6 +50,8 @@ impl InnerCtx {
 		}
 		res.core_ctx
 			.set_decimal_separator_style(config.decimal_separator);
+		res.core_ctx
+			.set_implicit_multiplication_precedence(config.implicit_multiplication_precedence);
 		let exchange_rate_handler = exchange_rates::ExchangeRateHandler {
 			enable_internet_access: config.enable_internet_access,
 			source: config.exchange_rate_source,

--- a/cli/src/default_config.toml
+++ b/cli/src/default_config.toml
@@ -52,6 +52,19 @@ exchange-rate-max-age = 259200
 #       separator. This is common in European languages.
 decimal-separator-style = "default"
 
+# Precedence for implicit multiplication and function application relative
+# to division. By default, fend keeps the historic behavior where `1 / 2m`
+# is parsed as `(1 / 2) m`. Set this to `higher-than-division` to parse it
+# as `1 / (2 m)` instead.
+#
+# Possible values:
+#   * `default`: uses the default
+#   * `same-as-division`: implicit multiplication has the same precedence
+#       as explicit multiplication and division
+#   * `higher-than-division`: implicit multiplication binds more tightly
+#       than explicit multiplication and division
+implicit-multiplication-precedence = "default"
+
 # This section controls the colors that are used by
 # fend. Make sure the `enable-colors` setting is
 # turned on for this to work.

--- a/core/src/eval.rs
+++ b/core/src/eval.rs
@@ -25,7 +25,7 @@ pub(crate) fn evaluate_to_value<I: Interrupt>(
 	for _ in 0..missing_open_parens {
 		tokens.insert(0, lexer::Token::Symbol(lexer::Symbol::OpenParens));
 	}
-	let parsed = parser::parse_tokens(&tokens)?;
+	let parsed = parser::parse_tokens(&tokens, context.implicit_multiplication_precedence)?;
 	let result = ast::evaluate(parsed, scope, attrs, spans, context, int)?;
 	Ok(result)
 }

--- a/core/src/lexer.rs
+++ b/core/src/lexer.rs
@@ -611,13 +611,7 @@ fn parse_symbol(ch: char, input: &mut &str) -> FResult<Token> {
 				return Err(FendError::UnexpectedChar(ch));
 			}
 		}
-		'>' => {
-			if test_next('>') {
-				Symbol::ShiftRight
-			} else {
-				return Err(FendError::UnexpectedChar(ch));
-			}
-		}
+		'>' if test_next('>') => Symbol::ShiftRight,
 		';' => Symbol::Semicolon,
 		_ => return Err(FendError::UnexpectedChar(ch)),
 	}))

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -281,6 +281,19 @@ pub enum DecimalSeparatorStyle {
 	Comma,
 }
 
+/// Controls how implicit multiplication/function application is parsed relative to division.
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
+#[non_exhaustive]
+pub enum ImplicitMultiplicationPrecedence {
+	/// Parse implicit multiplication with the same precedence as explicit multiplication and division.
+	/// This keeps the historic fend behavior, where `1 / 2m` is parsed like `(1 / 2) m`.
+	#[default]
+	SameAsDivision,
+	/// Parse implicit multiplication more tightly than explicit multiplication and division.
+	/// In this mode, `1 / 2m` is parsed like `1 / (2 m)`.
+	HigherThanDivision,
+}
+
 impl DecimalSeparatorStyle {
 	fn decimal_separator(self) -> char {
 		match self {
@@ -315,6 +328,7 @@ pub struct Context {
 	get_exchange_rate_v2: Option<Arc<dyn ExchangeRateFnV2 + Send + Sync>>,
 	custom_units: Vec<(String, String, String)>,
 	decimal_separator: DecimalSeparatorStyle,
+	implicit_multiplication_precedence: ImplicitMultiplicationPrecedence,
 	is_preview: bool,
 }
 
@@ -330,6 +344,7 @@ impl Clone for Context {
 			get_exchange_rate_v2: self.get_exchange_rate_v2.clone(),
 			custom_units: self.custom_units.clone(),
 			decimal_separator: self.decimal_separator,
+			implicit_multiplication_precedence: self.implicit_multiplication_precedence,
 			is_preview: self.is_preview,
 		}
 	}
@@ -346,6 +361,10 @@ impl fmt::Debug for Context {
 			.field("echo_result", &self.echo_result)
 			.field("custom_units", &self.custom_units)
 			.field("decimal_separator", &self.decimal_separator)
+			.field(
+				"implicit_multiplication_precedence",
+				&self.implicit_multiplication_precedence,
+			)
 			.field("is_preview", &self.is_preview)
 			.finish_non_exhaustive()
 	}
@@ -371,6 +390,7 @@ impl Context {
 			get_exchange_rate_v2: None,
 			custom_units: vec![],
 			decimal_separator: DecimalSeparatorStyle::default(),
+			implicit_multiplication_precedence: ImplicitMultiplicationPrecedence::default(),
 			is_preview: false,
 		}
 	}
@@ -519,6 +539,14 @@ impl Context {
 	/// change the number format from e.g. `1,234.00` to `1.234,00`.
 	pub fn set_decimal_separator_style(&mut self, style: DecimalSeparatorStyle) {
 		self.decimal_separator = style;
+	}
+
+	/// Sets how implicit multiplication is parsed relative to division.
+	pub fn set_implicit_multiplication_precedence(
+		&mut self,
+		precedence: ImplicitMultiplicationPrecedence,
+	) {
+		self.implicit_multiplication_precedence = precedence;
 	}
 }
 

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -1,3 +1,4 @@
+use crate::ImplicitMultiplicationPrecedence;
 use crate::ast::{Bop, Expr};
 use crate::lexer::{Symbol, Token};
 use crate::value::Value;
@@ -83,11 +84,15 @@ fn parse_number(input: &[Token]) -> ParseResult<'_> {
 	}
 }
 
-fn parse_ident(input: &[Token]) -> ParseResult<'_> {
+fn parse_ident(
+	input: &[Token],
+	implicit_multiplication_precedence: ImplicitMultiplicationPrecedence,
+) -> ParseResult<'_> {
 	match parse_token(input)? {
 		(Token::Ident(ident), remaining) => {
 			if ident.as_str() == "light"
-				&& let Ok((ident2, remaining2)) = parse_ident(remaining)
+				&& let Ok((ident2, remaining2)) =
+					parse_ident(remaining, implicit_multiplication_precedence)
 			{
 				return Ok((
 					Expr::Apply(Box::new(Expr::Ident(ident)), Box::new(ident2)),
@@ -95,7 +100,8 @@ fn parse_ident(input: &[Token]) -> ParseResult<'_> {
 				));
 			}
 			if let Ok(((), remaining2)) = parse_fixed_symbol(remaining, Symbol::Of) {
-				let (inner, remaining3) = parse_parens_or_literal(remaining2)?;
+				let (inner, remaining3) =
+					parse_parens_or_literal(remaining2, implicit_multiplication_precedence)?;
 				Ok((Expr::Of(ident, Box::new(inner)), remaining3))
 			} else {
 				Ok((Expr::Ident(ident), remaining))
@@ -105,12 +111,15 @@ fn parse_ident(input: &[Token]) -> ParseResult<'_> {
 	}
 }
 
-fn parse_parens(input: &[Token]) -> ParseResult<'_> {
+fn parse_parens(
+	input: &[Token],
+	implicit_multiplication_precedence: ImplicitMultiplicationPrecedence,
+) -> ParseResult<'_> {
 	let ((), input) = parse_fixed_symbol(input, Symbol::OpenParens)?;
 	if let Ok(((), remaining)) = parse_fixed_symbol(input, Symbol::CloseParens) {
 		return Ok((Expr::Literal(Value::Unit), remaining));
 	}
-	let (inner, mut input) = parse_expression(input)?;
+	let (inner, mut input) = parse_expression(input, implicit_multiplication_precedence)?;
 	// allow omitting closing parentheses at end of input
 	if !input.is_empty() {
 		let ((), remaining) = parse_fixed_symbol(input, Symbol::CloseParens)?;
@@ -119,33 +128,47 @@ fn parse_parens(input: &[Token]) -> ParseResult<'_> {
 	Ok((Expr::Parens(Box::new(inner)), input))
 }
 
-fn parse_backslash_lambda(input: &[Token]) -> ParseResult<'_> {
+fn parse_backslash_lambda(
+	input: &[Token],
+	implicit_multiplication_precedence: ImplicitMultiplicationPrecedence,
+) -> ParseResult<'_> {
 	let ((), input) = parse_fixed_symbol(input, Symbol::Backslash)?;
-	let (Expr::Ident(ident), input) = parse_ident(input)? else {
+	let (Expr::Ident(ident), input) = parse_ident(input, implicit_multiplication_precedence)?
+	else {
 		return Err(ParseError::ExpectedIdentifier);
 	};
 	let ((), input) =
 		parse_fixed_symbol(input, Symbol::Dot).map_err(|_| ParseError::ExpectedDotInLambda)?;
-	let (rhs, input) = parse_function(input)?;
+	let (rhs, input) = parse_function(input, implicit_multiplication_precedence)?;
 	Ok((Expr::Fn(ident, Box::new(rhs)), input))
 }
 
-fn parse_parens_or_literal(input: &[Token]) -> ParseResult<'_> {
+fn parse_parens_or_literal(
+	input: &[Token],
+	implicit_multiplication_precedence: ImplicitMultiplicationPrecedence,
+) -> ParseResult<'_> {
 	let (token, remaining) = parse_token(input)?;
 
 	match token {
 		Token::Num(_) => parse_number(input),
-		Token::Ident(_) => parse_ident(input),
+		Token::Ident(_) => parse_ident(input, implicit_multiplication_precedence),
 		Token::StringLiteral(s) => Ok((Expr::Literal(Value::String(s)), remaining)),
-		Token::Symbol(Symbol::OpenParens) => parse_parens(input),
-		Token::Symbol(Symbol::Backslash) => parse_backslash_lambda(input),
+		Token::Symbol(Symbol::OpenParens) => {
+			parse_parens(input, implicit_multiplication_precedence)
+		}
+		Token::Symbol(Symbol::Backslash) => {
+			parse_backslash_lambda(input, implicit_multiplication_precedence)
+		}
 		Token::Symbol(s) => Err(ParseError::UnexpectedSymbol(s)),
 		Token::Date(d) => Ok((Expr::Literal(Value::Date(d)), remaining)),
 	}
 }
 
-fn parse_factorial(input: &[Token]) -> ParseResult<'_> {
-	let (mut res, mut input) = parse_parens_or_literal(input)?;
+fn parse_factorial(
+	input: &[Token],
+	implicit_multiplication_precedence: ImplicitMultiplicationPrecedence,
+) -> ParseResult<'_> {
+	let (mut res, mut input) = parse_parens_or_literal(input, implicit_multiplication_precedence)?;
 	while let Ok(((), remaining)) = parse_fixed_symbol(input, Symbol::Factorial) {
 		res = Expr::Factorial(Box::new(res));
 		input = remaining;
@@ -153,34 +176,45 @@ fn parse_factorial(input: &[Token]) -> ParseResult<'_> {
 	Ok((res, input))
 }
 
-fn parse_power(input: &[Token], allow_unary: bool) -> ParseResult<'_> {
+fn parse_power(
+	input: &[Token],
+	allow_unary: bool,
+	implicit_multiplication_precedence: ImplicitMultiplicationPrecedence,
+) -> ParseResult<'_> {
 	if allow_unary {
 		if let Ok(((), remaining)) = parse_fixed_symbol(input, Symbol::Sub) {
-			let (result, remaining) = parse_power(remaining, true)?;
+			let (result, remaining) =
+				parse_power(remaining, true, implicit_multiplication_precedence)?;
 			return Ok((Expr::UnaryMinus(Box::new(result)), remaining));
 		}
 		if let Ok(((), remaining)) = parse_fixed_symbol(input, Symbol::Add) {
-			let (result, remaining) = parse_power(remaining, true)?;
+			let (result, remaining) =
+				parse_power(remaining, true, implicit_multiplication_precedence)?;
 			return Ok((Expr::UnaryPlus(Box::new(result)), remaining));
 		}
 		// The precedence of unary division relative to exponentiation
 		// is not important because /a^b -> (1/a)^b == 1/(a^b)
 		if let Ok(((), remaining)) = parse_fixed_symbol(input, Symbol::Div) {
-			let (result, remaining) = parse_power(remaining, true)?;
+			let (result, remaining) =
+				parse_power(remaining, true, implicit_multiplication_precedence)?;
 			return Ok((Expr::UnaryDiv(Box::new(result)), remaining));
 		}
 	}
-	let (mut result, mut input) = parse_factorial(input)?;
+	let (mut result, mut input) = parse_factorial(input, implicit_multiplication_precedence)?;
 	if let Ok(((), remaining)) = parse_fixed_symbol(input, Symbol::Pow) {
-		let (rhs, remaining) = parse_power(remaining, true)?;
+		let (rhs, remaining) = parse_power(remaining, true, implicit_multiplication_precedence)?;
 		result = Expr::Bop(Bop::Pow, Box::new(result), Box::new(rhs));
 		input = remaining;
 	}
 	Ok((result, input))
 }
 
-fn parse_apply_cont<'a>(input: &'a [Token], lhs: &Expr) -> ParseResult<'a> {
-	let (rhs, input) = parse_power(input, false)?;
+fn parse_apply_cont<'a>(
+	input: &'a [Token],
+	lhs: &Expr,
+	implicit_multiplication_precedence: ImplicitMultiplicationPrecedence,
+) -> ParseResult<'a> {
+	let (rhs, input) = parse_power(input, false, implicit_multiplication_precedence)?;
 	Ok((
 		match (lhs, &rhs) {
 			(
@@ -221,7 +255,11 @@ fn parse_apply_cont<'a>(input: &'a [Token], lhs: &Expr) -> ParseResult<'a> {
 	))
 }
 
-fn parse_mixed_fraction<'a>(input: &'a [Token], lhs: &Expr) -> ParseResult<'a> {
+fn parse_mixed_fraction<'a>(
+	input: &'a [Token],
+	lhs: &Expr,
+	implicit_multiplication_precedence: ImplicitMultiplicationPrecedence,
+) -> ParseResult<'a> {
 	let (positive, lhs, other_factor) = match lhs {
 		Expr::Literal(Value::Num(_)) => (true, lhs, None),
 		Expr::UnaryMinus(x) => {
@@ -244,13 +282,13 @@ fn parse_mixed_fraction<'a>(input: &'a [Token], lhs: &Expr) -> ParseResult<'a> {
 		},
 		_ => return Err(ParseError::InvalidMixedFraction),
 	};
-	let (rhs_top, input) = parse_power(input, false)?;
+	let (rhs_top, input) = parse_power(input, false, implicit_multiplication_precedence)?;
 	if let Expr::Literal(Value::Num(_)) = rhs_top {
 	} else {
 		return Err(ParseError::InvalidMixedFraction);
 	}
 	let ((), input) = parse_fixed_symbol(input, Symbol::Div)?;
-	let (rhs_bottom, input) = parse_power(input, false)?;
+	let (rhs_bottom, input) = parse_power(input, false, implicit_multiplication_precedence)?;
 	if let Expr::Literal(Value::Num(_)) = rhs_bottom {
 	} else {
 		return Err(ParseError::InvalidMixedFraction);
@@ -271,26 +309,38 @@ fn parse_mixed_fraction<'a>(input: &'a [Token], lhs: &Expr) -> ParseResult<'a> {
 	Ok((mixed_fraction, input))
 }
 
-fn parse_multiplication_cont(input: &[Token]) -> ParseResult<'_> {
+fn parse_multiplication_cont(
+	input: &[Token],
+	implicit_multiplication_precedence: ImplicitMultiplicationPrecedence,
+) -> ParseResult<'_> {
 	let ((), input) = parse_fixed_symbol(input, Symbol::Mul)?;
-	let (b, input) = parse_power(input, true)?;
+	let (b, input) = parse_multiplicative_operand(input, implicit_multiplication_precedence)?;
 	Ok((b, input))
 }
 
-fn parse_division_cont(input: &[Token]) -> ParseResult<'_> {
+fn parse_division_cont(
+	input: &[Token],
+	implicit_multiplication_precedence: ImplicitMultiplicationPrecedence,
+) -> ParseResult<'_> {
 	let ((), input) = parse_fixed_symbol(input, Symbol::Div)?;
-	let (b, input) = parse_power(input, true)?;
+	let (b, input) = parse_multiplicative_operand(input, implicit_multiplication_precedence)?;
 	Ok((b, input))
 }
 
-fn parse_modulo_cont(input: &[Token]) -> ParseResult<'_> {
+fn parse_modulo_cont(
+	input: &[Token],
+	implicit_multiplication_precedence: ImplicitMultiplicationPrecedence,
+) -> ParseResult<'_> {
 	let ((), input) = parse_fixed_symbol(input, Symbol::Mod)?;
-	let (b, input) = parse_power(input, true)?;
+	let (b, input) = parse_multiplicative_operand(input, implicit_multiplication_precedence)?;
 	Ok((b, input))
 }
 
 // try parsing `%` as modulo
-fn parse_modulo2_cont(input: &[Token]) -> ParseResult<'_> {
+fn parse_modulo2_cont(
+	input: &[Token],
+	implicit_multiplication_precedence: ImplicitMultiplicationPrecedence,
+) -> ParseResult<'_> {
 	let (token, input) = parse_token(input)?;
 	if let Token::Ident(ident) = token {
 		if ident.as_str() != "%" {
@@ -306,29 +356,75 @@ fn parse_modulo2_cont(input: &[Token]) -> ParseResult<'_> {
 	}) {
 		return Err(ParseError::UnexpectedInput);
 	}
-	let (b, input) = parse_power(input, true)?;
+	let (b, input) = parse_multiplicative_operand(input, implicit_multiplication_precedence)?;
 	Ok((b, input))
 }
 
-fn parse_multiplicative(input: &[Token]) -> ParseResult<'_> {
-	let (mut res, mut input) = parse_power(input, true)?;
+fn parse_apply_chain(
+	input: &[Token],
+	implicit_multiplication_precedence: ImplicitMultiplicationPrecedence,
+) -> ParseResult<'_> {
+	let (mut res, mut input) = parse_power(input, true, implicit_multiplication_precedence)?;
+	while let Ok((new_res, remaining)) =
+		parse_apply_cont(input, &res, implicit_multiplication_precedence)
+	{
+		res = new_res;
+		input = remaining;
+	}
+	Ok((res, input))
+}
+
+fn parse_multiplicative_operand(
+	input: &[Token],
+	implicit_multiplication_precedence: ImplicitMultiplicationPrecedence,
+) -> ParseResult<'_> {
+	match implicit_multiplication_precedence {
+		ImplicitMultiplicationPrecedence::SameAsDivision => {
+			parse_power(input, true, implicit_multiplication_precedence)
+		}
+		ImplicitMultiplicationPrecedence::HigherThanDivision => {
+			parse_apply_chain(input, implicit_multiplication_precedence)
+		}
+	}
+}
+
+fn parse_multiplicative(
+	input: &[Token],
+	implicit_multiplication_precedence: ImplicitMultiplicationPrecedence,
+) -> ParseResult<'_> {
+	let (mut res, mut input) =
+		parse_multiplicative_operand(input, implicit_multiplication_precedence)?;
 	loop {
-		if let Ok((term, remaining)) = parse_multiplication_cont(input) {
+		if let Ok((term, remaining)) =
+			parse_multiplication_cont(input, implicit_multiplication_precedence)
+		{
 			res = Expr::Bop(Bop::Mul, Box::new(res.clone()), Box::new(term));
 			input = remaining;
-		} else if let Ok((term, remaining)) = parse_division_cont(input) {
+		} else if let Ok((term, remaining)) =
+			parse_division_cont(input, implicit_multiplication_precedence)
+		{
 			res = Expr::Bop(Bop::Div, Box::new(res.clone()), Box::new(term));
 			input = remaining;
-		} else if let Ok((term, remaining)) = parse_modulo_cont(input) {
+		} else if let Ok((term, remaining)) =
+			parse_modulo_cont(input, implicit_multiplication_precedence)
+		{
 			res = Expr::Bop(Bop::Mod, Box::new(res.clone()), Box::new(term));
 			input = remaining;
-		} else if let Ok((term, remaining)) = parse_modulo2_cont(input) {
+		} else if let Ok((term, remaining)) =
+			parse_modulo2_cont(input, implicit_multiplication_precedence)
+		{
 			res = Expr::Bop(Bop::Mod, Box::new(res.clone()), Box::new(term));
 			input = remaining;
-		} else if let Ok((new_res, remaining)) = parse_mixed_fraction(input, &res) {
+		} else if let Ok((new_res, remaining)) =
+			parse_mixed_fraction(input, &res, implicit_multiplication_precedence)
+		{
 			res = new_res;
 			input = remaining;
-		} else if let Ok((new_res, remaining)) = parse_apply_cont(input, &res) {
+		} else if implicit_multiplication_precedence
+			== ImplicitMultiplicationPrecedence::SameAsDivision
+			&& let Ok((new_res, remaining)) =
+				parse_apply_cont(input, &res, implicit_multiplication_precedence)
+		{
 			res = new_res;
 			input = remaining;
 		} else {
@@ -338,9 +434,13 @@ fn parse_multiplicative(input: &[Token]) -> ParseResult<'_> {
 	Ok((res, input))
 }
 
-fn parse_implicit_addition(input: &[Token]) -> ParseResult<'_> {
-	let (res, input) = parse_multiplicative(input)?;
-	if let Ok((rhs, remaining)) = parse_implicit_addition(input) {
+fn parse_implicit_addition(
+	input: &[Token],
+	implicit_multiplication_precedence: ImplicitMultiplicationPrecedence,
+) -> ParseResult<'_> {
+	let (res, input) = parse_multiplicative(input, implicit_multiplication_precedence)?;
+	if let Ok((rhs, remaining)) = parse_implicit_addition(input, implicit_multiplication_precedence)
+	{
 		// n i n i, n i i n i i, etc. (n: number literal, i: identifier)
 		if let (
 			Expr::ApplyMul(_, _),
@@ -356,34 +456,52 @@ fn parse_implicit_addition(input: &[Token]) -> ParseResult<'_> {
 	Ok((res, input))
 }
 
-fn parse_addition_cont(input: &[Token]) -> ParseResult<'_> {
+fn parse_addition_cont(
+	input: &[Token],
+	implicit_multiplication_precedence: ImplicitMultiplicationPrecedence,
+) -> ParseResult<'_> {
 	let ((), input) = parse_fixed_symbol(input, Symbol::Add)?;
-	let (b, input) = parse_implicit_addition(input)?;
+	let (b, input) = parse_implicit_addition(input, implicit_multiplication_precedence)?;
 	Ok((b, input))
 }
 
-fn parse_subtraction_cont(input: &[Token]) -> ParseResult<'_> {
+fn parse_subtraction_cont(
+	input: &[Token],
+	implicit_multiplication_precedence: ImplicitMultiplicationPrecedence,
+) -> ParseResult<'_> {
 	let ((), input) = parse_fixed_symbol(input, Symbol::Sub)?;
-	let (b, input) = parse_implicit_addition(input)?;
+	let (b, input) = parse_implicit_addition(input, implicit_multiplication_precedence)?;
 	Ok((b, input))
 }
 
-fn parse_to_cont(input: &[Token]) -> ParseResult<'_> {
+fn parse_to_cont(
+	input: &[Token],
+	implicit_multiplication_precedence: ImplicitMultiplicationPrecedence,
+) -> ParseResult<'_> {
 	let ((), input) = parse_fixed_symbol(input, Symbol::UnitConversion)?;
-	let (b, input) = parse_implicit_addition(input)?;
+	let (b, input) = parse_implicit_addition(input, implicit_multiplication_precedence)?;
 	Ok((b, input))
 }
 
-fn parse_additive(input: &[Token]) -> ParseResult<'_> {
-	let (mut res, mut input) = parse_implicit_addition(input)?;
+fn parse_additive(
+	input: &[Token],
+	implicit_multiplication_precedence: ImplicitMultiplicationPrecedence,
+) -> ParseResult<'_> {
+	let (mut res, mut input) = parse_implicit_addition(input, implicit_multiplication_precedence)?;
 	loop {
-		if let Ok((term, remaining)) = parse_addition_cont(input) {
+		if let Ok((term, remaining)) =
+			parse_addition_cont(input, implicit_multiplication_precedence)
+		{
 			res = Expr::Bop(Bop::Plus, Box::new(res), Box::new(term));
 			input = remaining;
-		} else if let Ok((term, remaining)) = parse_subtraction_cont(input) {
+		} else if let Ok((term, remaining)) =
+			parse_subtraction_cont(input, implicit_multiplication_precedence)
+		{
 			res = Expr::Bop(Bop::Minus, Box::new(res), Box::new(term));
 			input = remaining;
-		} else if let Ok((term, remaining)) = parse_to_cont(input) {
+		} else if let Ok((term, remaining)) =
+			parse_to_cont(input, implicit_multiplication_precedence)
+		{
 			res = Expr::As(Box::new(res), Box::new(term));
 			input = remaining;
 		} else {
@@ -393,11 +511,14 @@ fn parse_additive(input: &[Token]) -> ParseResult<'_> {
 	Ok((res, input))
 }
 
-fn parse_bitshifts(input: &[Token]) -> ParseResult<'_> {
-	let (mut result, mut input) = parse_additive(input)?;
+fn parse_bitshifts(
+	input: &[Token],
+	implicit_multiplication_precedence: ImplicitMultiplicationPrecedence,
+) -> ParseResult<'_> {
+	let (mut result, mut input) = parse_additive(input, implicit_multiplication_precedence)?;
 	loop {
 		if let Ok(((), remaining)) = parse_fixed_symbol(input, Symbol::ShiftLeft) {
-			let (rhs, remaining) = parse_additive(remaining)?;
+			let (rhs, remaining) = parse_additive(remaining, implicit_multiplication_precedence)?;
 			result = Expr::Bop(
 				Bop::Bitwise(crate::ast::BitwiseBop::LeftShift),
 				Box::new(result),
@@ -405,7 +526,7 @@ fn parse_bitshifts(input: &[Token]) -> ParseResult<'_> {
 			);
 			input = remaining;
 		} else if let Ok(((), remaining)) = parse_fixed_symbol(input, Symbol::ShiftRight) {
-			let (rhs, remaining) = parse_additive(remaining)?;
+			let (rhs, remaining) = parse_additive(remaining, implicit_multiplication_precedence)?;
 			result = Expr::Bop(
 				Bop::Bitwise(crate::ast::BitwiseBop::RightShift),
 				Box::new(result),
@@ -419,10 +540,13 @@ fn parse_bitshifts(input: &[Token]) -> ParseResult<'_> {
 	Ok((result, input))
 }
 
-fn parse_bitwise_and(input: &[Token]) -> ParseResult<'_> {
-	let (mut result, mut input) = parse_bitshifts(input)?;
+fn parse_bitwise_and(
+	input: &[Token],
+	implicit_multiplication_precedence: ImplicitMultiplicationPrecedence,
+) -> ParseResult<'_> {
+	let (mut result, mut input) = parse_bitshifts(input, implicit_multiplication_precedence)?;
 	while let Ok(((), remaining)) = parse_fixed_symbol(input, Symbol::BitwiseAnd) {
-		let (rhs, remaining) = parse_bitshifts(remaining)?;
+		let (rhs, remaining) = parse_bitshifts(remaining, implicit_multiplication_precedence)?;
 		result = Expr::Bop(
 			Bop::Bitwise(crate::ast::BitwiseBop::And),
 			Box::new(result),
@@ -433,10 +557,13 @@ fn parse_bitwise_and(input: &[Token]) -> ParseResult<'_> {
 	Ok((result, input))
 }
 
-fn parse_bitwise_xor(input: &[Token]) -> ParseResult<'_> {
-	let (mut result, mut input) = parse_bitwise_and(input)?;
+fn parse_bitwise_xor(
+	input: &[Token],
+	implicit_multiplication_precedence: ImplicitMultiplicationPrecedence,
+) -> ParseResult<'_> {
+	let (mut result, mut input) = parse_bitwise_and(input, implicit_multiplication_precedence)?;
 	while let Ok(((), remaining)) = parse_fixed_symbol(input, Symbol::BitwiseXor) {
-		let (rhs, remaining) = parse_bitwise_and(remaining)?;
+		let (rhs, remaining) = parse_bitwise_and(remaining, implicit_multiplication_precedence)?;
 		result = Expr::Bop(
 			Bop::Bitwise(crate::ast::BitwiseBop::Xor),
 			Box::new(result),
@@ -447,10 +574,13 @@ fn parse_bitwise_xor(input: &[Token]) -> ParseResult<'_> {
 	Ok((result, input))
 }
 
-fn parse_bitwise_or(input: &[Token]) -> ParseResult<'_> {
-	let (mut result, mut input) = parse_bitwise_xor(input)?;
+fn parse_bitwise_or(
+	input: &[Token],
+	implicit_multiplication_precedence: ImplicitMultiplicationPrecedence,
+) -> ParseResult<'_> {
+	let (mut result, mut input) = parse_bitwise_xor(input, implicit_multiplication_precedence)?;
 	while let Ok(((), remaining)) = parse_fixed_symbol(input, Symbol::BitwiseOr) {
-		let (rhs, remaining) = parse_bitwise_xor(remaining)?;
+		let (rhs, remaining) = parse_bitwise_xor(remaining, implicit_multiplication_precedence)?;
 		result = Expr::Bop(
 			Bop::Bitwise(crate::ast::BitwiseBop::Or),
 			Box::new(result),
@@ -461,31 +591,40 @@ fn parse_bitwise_or(input: &[Token]) -> ParseResult<'_> {
 	Ok((result, input))
 }
 
-fn parse_combination(input: &[Token]) -> ParseResult<'_> {
-	let (mut result, mut input) = parse_bitwise_or(input)?;
+fn parse_combination(
+	input: &[Token],
+	implicit_multiplication_precedence: ImplicitMultiplicationPrecedence,
+) -> ParseResult<'_> {
+	let (mut result, mut input) = parse_bitwise_or(input, implicit_multiplication_precedence)?;
 	while let Ok(((), remaining)) = parse_fixed_symbol(input, Symbol::Combination) {
-		let (rhs, remaining) = parse_bitwise_or(remaining)?;
+		let (rhs, remaining) = parse_bitwise_or(remaining, implicit_multiplication_precedence)?;
 		result = Expr::Bop(Bop::Combination, Box::new(result), Box::new(rhs));
 		input = remaining;
 	}
 	Ok((result, input))
 }
 
-fn parse_permutation(input: &[Token]) -> ParseResult<'_> {
-	let (mut result, mut input) = parse_combination(input)?;
+fn parse_permutation(
+	input: &[Token],
+	implicit_multiplication_precedence: ImplicitMultiplicationPrecedence,
+) -> ParseResult<'_> {
+	let (mut result, mut input) = parse_combination(input, implicit_multiplication_precedence)?;
 	while let Ok(((), remaining)) = parse_fixed_symbol(input, Symbol::Permutation) {
-		let (rhs, remaining) = parse_combination(remaining)?;
+		let (rhs, remaining) = parse_combination(remaining, implicit_multiplication_precedence)?;
 		result = Expr::Bop(Bop::Permutation, Box::new(result), Box::new(rhs));
 		input = remaining;
 	}
 	Ok((result, input))
 }
 
-fn parse_function(input: &[Token]) -> ParseResult<'_> {
-	let (lhs, input) = parse_permutation(input)?;
+fn parse_function(
+	input: &[Token],
+	implicit_multiplication_precedence: ImplicitMultiplicationPrecedence,
+) -> ParseResult<'_> {
+	let (lhs, input) = parse_permutation(input, implicit_multiplication_precedence)?;
 	if let Ok(((), remaining)) = parse_fixed_symbol(input, Symbol::Fn) {
 		if let Expr::Ident(s) = lhs {
-			let (rhs, remaining) = parse_function(remaining)?;
+			let (rhs, remaining) = parse_function(remaining, implicit_multiplication_precedence)?;
 			return Ok((Expr::Fn(s, Box::new(rhs)), remaining));
 		}
 		return Err(ParseError::ExpectedIdentifierAsArgument);
@@ -493,16 +632,19 @@ fn parse_function(input: &[Token]) -> ParseResult<'_> {
 	Ok((lhs, input))
 }
 
-fn parse_equality(input: &[Token]) -> ParseResult<'_> {
-	let (lhs, input) = parse_function(input)?;
+fn parse_equality(
+	input: &[Token],
+	implicit_multiplication_precedence: ImplicitMultiplicationPrecedence,
+) -> ParseResult<'_> {
+	let (lhs, input) = parse_function(input, implicit_multiplication_precedence)?;
 	if let Ok(((), remaining)) = parse_fixed_symbol(input, Symbol::DoubleEquals) {
-		let (rhs, remaining) = parse_function(remaining)?;
+		let (rhs, remaining) = parse_function(remaining, implicit_multiplication_precedence)?;
 		Ok((
 			Expr::Equality(true, Box::new(lhs), Box::new(rhs)),
 			remaining,
 		))
 	} else if let Ok(((), remaining)) = parse_fixed_symbol(input, Symbol::NotEquals) {
-		let (rhs, remaining) = parse_function(remaining)?;
+		let (rhs, remaining) = parse_function(remaining, implicit_multiplication_precedence)?;
 		Ok((
 			Expr::Equality(false, Box::new(lhs), Box::new(rhs)),
 			remaining,
@@ -512,11 +654,14 @@ fn parse_equality(input: &[Token]) -> ParseResult<'_> {
 	}
 }
 
-fn parse_assignment(input: &[Token]) -> ParseResult<'_> {
-	let (lhs, input) = parse_equality(input)?;
+fn parse_assignment(
+	input: &[Token],
+	implicit_multiplication_precedence: ImplicitMultiplicationPrecedence,
+) -> ParseResult<'_> {
+	let (lhs, input) = parse_equality(input, implicit_multiplication_precedence)?;
 	if let Ok(((), remaining)) = parse_fixed_symbol(input, Symbol::Equals) {
 		if let Expr::Ident(s) = lhs {
-			let (rhs, remaining) = parse_assignment(remaining)?;
+			let (rhs, remaining) = parse_assignment(remaining, implicit_multiplication_precedence)?;
 			return Ok((Expr::Assign(s, Box::new(rhs)), remaining));
 		}
 		return Err(ParseError::ExpectedIdentifierInAssignment);
@@ -524,32 +669,41 @@ fn parse_assignment(input: &[Token]) -> ParseResult<'_> {
 	Ok((lhs, input))
 }
 
-fn parse_statements(mut input: &[Token]) -> ParseResult<'_> {
+fn parse_statements(
+	mut input: &[Token],
+	implicit_multiplication_precedence: ImplicitMultiplicationPrecedence,
+) -> ParseResult<'_> {
 	while let Ok(((), remaining)) = parse_fixed_symbol(input, Symbol::Semicolon) {
 		input = remaining;
 	}
 	if input.is_empty() {
 		return Ok((Expr::Literal(Value::Unit), &[]));
 	}
-	let (mut result, mut input) = parse_assignment(input)?;
+	let (mut result, mut input) = parse_assignment(input, implicit_multiplication_precedence)?;
 	while let Ok(((), remaining)) = parse_fixed_symbol(input, Symbol::Semicolon) {
 		if remaining.is_empty() || matches!(remaining[0], Token::Symbol(Symbol::Semicolon)) {
 			input = remaining;
 			continue;
 		}
-		let (rhs, remaining) = parse_assignment(remaining)?;
+		let (rhs, remaining) = parse_assignment(remaining, implicit_multiplication_precedence)?;
 		result = Expr::Statements(Box::new(result), Box::new(rhs));
 		input = remaining;
 	}
 	Ok((result, input))
 }
 
-pub(crate) fn parse_expression(input: &[Token]) -> ParseResult<'_> {
-	parse_statements(input)
+pub(crate) fn parse_expression(
+	input: &[Token],
+	implicit_multiplication_precedence: ImplicitMultiplicationPrecedence,
+) -> ParseResult<'_> {
+	parse_statements(input, implicit_multiplication_precedence)
 }
 
-pub(crate) fn parse_tokens(input: &[Token]) -> Result<Expr, ParseError> {
-	let (res, remaining) = parse_expression(input)?;
+pub(crate) fn parse_tokens(
+	input: &[Token],
+	implicit_multiplication_precedence: ImplicitMultiplicationPrecedence,
+) -> Result<Expr, ParseError> {
+	let (res, remaining) = parse_expression(input, implicit_multiplication_precedence)?;
 	if !remaining.is_empty() {
 		return Err(ParseError::UnexpectedInput);
 	}

--- a/core/tests/integration_tests.rs
+++ b/core/tests/integration_tests.rs
@@ -2224,6 +2224,38 @@ fn units_14() {
 }
 
 #[test]
+fn implicit_multiplication_same_precedence_as_division_by_default() {
+	let mut context = Context::new();
+	assert_eq!(
+		evaluate("5.6 L / 100km", &mut context)
+			.unwrap()
+			.get_main_result(),
+		"0.056 L km"
+	);
+}
+
+#[test]
+fn implicit_multiplication_higher_precedence_than_division() {
+	let mut context = Context::new();
+	context.set_exchange_rate_handler_v2(fend_core::test_utils::DummyCurrencyHandler);
+	context.set_implicit_multiplication_precedence(
+		fend_core::ImplicitMultiplicationPrecedence::HigherThanDivision,
+	);
+	assert_eq!(
+		evaluate("5.6 L / 100km", &mut context)
+			.unwrap()
+			.get_main_result(),
+		"0.056 L / km"
+	);
+	assert_eq!(
+		evaluate("83 km * (5.6 L / 100km) * ($1.9 / L) * 2", &mut context)
+			.unwrap()
+			.get_main_result(),
+		"$17.6624"
+	);
+}
+
+#[test]
 fn units_15() {
 	test_eval("5 i/2", "2.5i");
 }


### PR DESCRIPTION
## Summary

Adds an opt-in parser/configuration option for implicit multiplication and function application to bind more tightly than explicit multiplication and division. This lets expressions like `5.6 L / 100km` parse as `5.6 L / (100 km)` when enabled, while preserving the existing behavior by default.

## Details

- Adds `fend_core::ImplicitMultiplicationPrecedence` and a `Context::set_implicit_multiplication_precedence` setter.
- Adds the CLI config key `implicit-multiplication-precedence`, with `default`/`same-as-division` retaining existing behavior and `higher-than-division` enabling the new parsing mode.
- Documents the new setting in the default config.
- Adds regression coverage for default behavior, opt-in behavior, and CLI config parsing.
- Includes a minimal lexer Clippy cleanup needed for the current toolchain.

## Validation

- `cargo test -q --workspace`
- `cargo clippy -q --workspace --all-targets`