### PR TITLE
Fix CLI clear command

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -4,7 +4,7 @@
 #![deny(elided_lifetimes_in_paths)]
 
 use std::fmt::Write;
-use std::{error, io, process};
+use std::{error, io, io::Write as _, process};
 
 mod args;
 mod color;
@@ -128,6 +128,7 @@ async fn repl_loop(config: &config::Config) -> ExitCode {
 				},
 				"clear" | "clear()" | ":clear" => {
 					print!("\x1b[2J\x1b[H");
+					io::stdout().flush().expect("failed to flush stdout");
 				}
 				line => {
 					interrupt.reset();


### PR DESCRIPTION
The `clear` command does not flush stdout, meaning it is broken in a standard Linux console environment. This PR adds a flush so the `clear` command works as expected.