### PR TITLE
Fix DOS in Date.add and Date.sub

### DIFF
--- a/core/src/date.rs
+++ b/core/src/date.rs
@@ -221,6 +221,7 @@ impl Date {
 			let mut result = self;
 			for _ in 0..num_days {
 				result = result.prev();
+				test_int(int)?;
 			}
 			Ok(Value::Date(result))
 		} else if rhs.unit_equal_to("week", int)? {
@@ -230,6 +231,7 @@ impl Date {
 				for _ in 0..7 {
 					result = result.prev();
 				}
+				test_int(int)?;
 			}
 			Ok(Value::Date(result))
 		} else if rhs.unit_equal_to("month", int)? {

--- a/core/src/date.rs
+++ b/core/src/date.rs
@@ -11,6 +11,7 @@ pub(crate) use day_of_week::DayOfWeek;
 pub(crate) use month::Month;
 use year::Year;
 
+use crate::interrupt::test_int;
 use crate::{Interrupt, error::FendError, ident::Ident, result::FResult, value::Value};
 
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -203,6 +204,7 @@ impl Date {
 			let num_days = rhs.try_as_usize_unit(int)?;
 			let mut result = self;
 			for _ in 0..num_days {
+				test_int(int)?;
 				result = result.next();
 			}
 			Ok(Value::Date(result))


### PR DESCRIPTION
## Changes

`@1970-01-01 + 213503982334 days` freezes the shell while trying to compute a preview. It doesn't get interrupted.

Fix that by checking for interrupt in the loop.  

<!-- Describe your changes here: -->



---

### Checklist

- [ ] I used LLMs or similar AI tools when creating this pull request
